### PR TITLE
Align modules with bounded contexts

### DIFF
--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { getSystemModuleById } from '@/data/system-modules';
+import {
+  LineChart as LineChartIcon,
+  PieChart,
+  BarChart3,
+  AlertTriangle,
+  Download
+} from 'lucide-react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Bar,
+  BarChart
+} from 'recharts';
+
+const performanceSeries = [
+  { mes: 'Jan', vendas: 420, procurement: 310, financeiro: 210 },
+  { mes: 'Fev', vendas: 460, procurement: 280, financeiro: 250 },
+  { mes: 'Mar', vendas: 510, procurement: 320, financeiro: 270 },
+  { mes: 'Abr', vendas: 530, procurement: 300, financeiro: 280 },
+  { mes: 'Mai', vendas: 550, procurement: 340, financeiro: 300 },
+  { mes: 'Jun', vendas: 590, procurement: 360, financeiro: 315 }
+];
+
+const dashboards = [
+  { nome: 'Executivo', utilizacao: 92, fontes: 'Vendas, Finanças, Procurement' },
+  { nome: 'Operações', utilizacao: 81, fontes: 'Inventário, Transporte' },
+  { nome: 'Clientes', utilizacao: 74, fontes: 'CRM, Serviços, Tickets' }
+];
+
+const eventos = [
+  { titulo: 'Atualização DRE', detalhes: 'Novos indicadores enviados pelo módulo Financeiro', prioridade: 'normal' },
+  { titulo: 'Alerta de Stock', detalhes: 'Inventário reportou ruptura na província de Tete', prioridade: 'alto' },
+  { titulo: 'Nova métrica POS', detalhes: 'Latência média do POS adicionada ao data lake', prioridade: 'normal' }
+];
+
+const funilVendas = [
+  { etapa: 'Leads', valor: 1200 },
+  { etapa: 'Qualificados', valor: 640 },
+  { etapa: 'Propostas', valor: 310 },
+  { etapa: 'Ganho', valor: 180 }
+];
+
+export default function AnalyticsDashboardPage() {
+  const moduleInfo = getSystemModuleById('analytics');
+
+  if (!moduleInfo) {
+    return null;
+  }
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-bold">{moduleInfo.title}</h1>
+          <Badge variant="outline" className="text-xs">
+            {moduleInfo.springModule}
+          </Badge>
+        </div>
+        <p className="text-muted-foreground max-w-3xl">{moduleInfo.description}</p>
+        <div className="flex flex-wrap gap-2">
+          <Button>
+            <Download className="mr-2 h-4 w-4" />Exportar Relatório
+          </Button>
+          <Button variant="outline">
+            <LineChartIcon className="mr-2 h-4 w-4" />Criar Dashboard
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {moduleInfo.responsibilities.map((responsibility) => (
+          <Card key={responsibility}>
+            <CardContent className="pt-6">
+              <p className="text-sm text-muted-foreground">Responsabilidade</p>
+              <p className="font-semibold mt-1">{responsibility}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <Card className="xl:col-span-2">
+          <CardHeader>
+            <CardTitle>Tendência de Métricas por Contexto</CardTitle>
+          </CardHeader>
+          <CardContent className="h-[320px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={performanceSeries}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="mes" />
+                <YAxis />
+                <Tooltip />
+                <Line type="monotone" dataKey="vendas" stroke="#ec4899" strokeWidth={2} />
+                <Line type="monotone" dataKey="procurement" stroke="#a855f7" strokeWidth={2} />
+                <Line type="monotone" dataKey="financeiro" stroke="#0ea5e9" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Utilização de Dashboards</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {dashboards.map((dashboard) => (
+              <div key={dashboard.nome} className="rounded-lg border p-3">
+                <div className="flex items-center justify-between">
+                  <p className="font-semibold">{dashboard.nome}</p>
+                  <Badge variant="secondary">{dashboard.utilizacao}%</Badge>
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">{dashboard.fontes}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Eventos de Dados</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {eventos.map((evento) => (
+              <div key={evento.titulo} className="flex items-start gap-3">
+                <div className={`rounded-full p-2 ${evento.prioridade === 'alto' ? 'bg-red-100 text-red-600' : 'bg-blue-100 text-blue-600'}`}>
+                  <AlertTriangle className="h-4 w-4" />
+                </div>
+                <div>
+                  <p className="font-semibold">{evento.titulo}</p>
+                  <p className="text-sm text-muted-foreground">{evento.detalhes}</p>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Funil de Conversão (Vendas &amp; POS)</CardTitle>
+          </CardHeader>
+          <CardContent className="h-[260px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={funilVendas} layout="vertical" barSize={24}>
+                <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+                <XAxis type="number" hide />
+                <YAxis type="category" dataKey="etapa" width={90} />
+                <Tooltip />
+                <Bar dataKey="valor" fill="#0ea5e9" radius={[4, 4, 4, 4]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Modelos Disponíveis</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 text-sm text-muted-foreground">
+          {moduleInfo.typescriptModels.map((model) => (
+            <div key={model} className="rounded-lg border p-3">
+              <p className="font-semibold text-gray-900 dark:text-gray-100">{model}</p>
+              <p>Consumido por relatórios e dashboards cross-módulo.</p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/core-tenancy/page.tsx
+++ b/src/app/(dashboard)/core-tenancy/page.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { getSystemModuleById } from '@/data/system-modules';
+import {
+  Building2,
+  ShieldCheck,
+  Users,
+  FileText,
+  Globe,
+  Layers,
+  KeyRound,
+  ShieldAlert
+} from 'lucide-react';
+
+export default function CoreTenancyDashboardPage() {
+  const moduleInfo = getSystemModuleById('core-tenancy');
+
+  if (!moduleInfo) {
+    return null;
+  }
+
+  const estatisticas = [
+    {
+      label: 'Tenants Ativos',
+      value: '18',
+      helper: '+2 vs último mês',
+      icon: Building2,
+      color: 'text-blue-600'
+    },
+    {
+      label: 'Utilizadores',
+      value: '214',
+      helper: '32 administradores',
+      icon: Users,
+      color: 'text-emerald-600'
+    },
+    {
+      label: 'Séries Documentais',
+      value: '64',
+      helper: '9 expirando em 30 dias',
+      icon: Layers,
+      color: 'text-purple-600'
+    },
+    {
+      label: 'Validações BI/NUIT',
+      value: '1.482',
+      helper: 'Últimos 7 dias',
+      icon: ShieldCheck,
+      color: 'text-orange-500'
+    }
+  ];
+
+  const eventosRecentes = [
+    {
+      tipo: 'Série Documental',
+      descricao: 'Nova série "FAT-2025" criada para o tenant Zambeze Agro',
+      data: 'Hoje · 09:42',
+      status: 'configurado'
+    },
+    {
+      tipo: 'Configuração Fiscal',
+      descricao: 'Atualização da taxa de ISPC do tenant UrbanFoods',
+      data: 'Ontem · 18:10',
+      status: 'pendente'
+    },
+    {
+      tipo: 'Utilizador',
+      descricao: 'Andre Matola promoveu-se para Tenant Admin',
+      data: 'Ontem · 10:21',
+      status: 'aprovado'
+    }
+  ];
+
+  const verificacoes = [
+    { titulo: 'NUIT', resultado: '100% válido', icon: ShieldCheck, color: 'text-green-600' },
+    { titulo: 'BI', resultado: '98,4% válido', icon: ShieldAlert, color: 'text-amber-600' },
+    { titulo: 'Email', resultado: '92% válido', icon: Globe, color: 'text-blue-600' }
+  ];
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-bold">{moduleInfo.title}</h1>
+          <Badge variant="outline" className="text-xs">
+            {moduleInfo.springModule}
+          </Badge>
+        </div>
+        <p className="text-muted-foreground max-w-3xl">{moduleInfo.description}</p>
+        <div className="flex flex-wrap gap-2">
+          <Button asChild variant="default">
+            <Link href="/dashboard">
+              <Users className="mr-2 h-4 w-4" />Gerir Tenants
+            </Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/dashboard">
+              <FileText className="mr-2 h-4 w-4" />Configurar Séries
+            </Link>
+          </Button>
+          <Button asChild variant="ghost">
+            <Link href="/dashboard">
+              <ShieldCheck className="mr-2 h-4 w-4" />Validar Identificadores
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {estatisticas.map((stat) => {
+          const Icon = stat.icon;
+          return (
+            <Card key={stat.label}>
+              <CardContent className="pt-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-muted-foreground">{stat.label}</p>
+                    <p className="text-3xl font-bold">{stat.value}</p>
+                    <p className="text-xs text-muted-foreground mt-1">{stat.helper}</p>
+                  </div>
+                  <Icon className={`h-10 w-10 ${stat.color}`} />
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <Card className="xl:col-span-2">
+          <CardHeader>
+            <CardTitle>Responsabilidades chave</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-3 text-sm text-muted-foreground">
+              {moduleInfo.responsibilities.map((responsibility) => (
+                <li key={responsibility} className="flex items-start gap-2">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-blue-500" />
+                  <span>{responsibility}</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Verificações recentes</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {verificacoes.map((verificacao) => {
+              const Icon = verificacao.icon;
+              return (
+                <div key={verificacao.titulo} className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">{verificacao.titulo}</p>
+                    <p className="text-sm text-muted-foreground">{verificacao.resultado}</p>
+                  </div>
+                  <Icon className={`h-5 w-5 ${verificacao.color}`} />
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Utilitários Partilhados</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-muted-foreground">
+              {moduleInfo.typescriptModels.map((model) => (
+                <div key={model} className="rounded-lg border p-3">
+                  <p className="font-medium text-gray-900 dark:text-gray-100">{model}</p>
+                  <p>Disponível no shared kernel</p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Eventos Recentes</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {eventosRecentes.map((evento) => (
+              <div key={evento.descricao} className="rounded-lg border p-3">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>{evento.tipo}</span>
+                  <span>{evento.data}</span>
+                </div>
+                <p className="mt-2 text-sm font-medium">{evento.descricao}</p>
+                <Badge
+                  variant={evento.status === 'aprovado' ? 'default' : evento.status === 'pendente' ? 'destructive' : 'secondary'}
+                  className="mt-3 capitalize"
+                >
+                  {evento.status}
+                </Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Segurança &amp; Compliance</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="rounded-lg border p-4">
+            <KeyRound className="h-5 w-5 text-blue-600" />
+            <p className="mt-2 font-semibold">Gestão de Acessos</p>
+            <p className="text-sm text-muted-foreground">
+              Políticas de password e MFA aplicadas em todos os tenants.
+            </p>
+          </div>
+          <div className="rounded-lg border p-4">
+            <ShieldCheck className="h-5 w-5 text-green-600" />
+            <p className="mt-2 font-semibold">Auditoria</p>
+            <p className="text-sm text-muted-foreground">
+              Log centralizado de alterações em configurações críticas.
+            </p>
+          </div>
+          <div className="rounded-lg border p-4">
+            <Globe className="h-5 w-5 text-purple-600" />
+            <p className="mt-2 font-semibold">Localização Fiscal</p>
+            <p className="text-sm text-muted-foreground">
+              Controlo de províncias/distritos e conversores monetários.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1,10 +1,12 @@
 
 'use client';
 
+import Link from 'next/link';
 import { useAuth } from '@/lib/auth-context';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { SYSTEM_MODULES } from '@/data/system-modules';
 import { 
   Building2, 
   Users, 
@@ -199,6 +201,70 @@ export default function Dashboard() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Módulos do Sistema */}
+        <section className="mt-12 space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+              Bounded Contexts &amp; Módulos
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Mapeamento dos modelos TypeScript e módulos Spring Modulith com acesso rápido aos dashboards.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+            {SYSTEM_MODULES.map((module) => {
+              const Icon = module.icon;
+              return (
+                <Card key={module.id} className="flex flex-col">
+                  <CardHeader>
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center space-x-3">
+                        <div className={`${module.accentColor} rounded-xl p-2 text-white`}>
+                          <Icon className="h-5 w-5" />
+                        </div>
+                        <div>
+                          <CardTitle className="text-lg">{module.title}</CardTitle>
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            {module.springModule}
+                          </p>
+                        </div>
+                      </div>
+                      <Badge variant="secondary" className="text-xs">
+                        {module.typescriptModels.length} modelos
+                      </Badge>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="flex-1 flex flex-col">
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      {module.description}
+                    </p>
+                    <div className="mt-4">
+                      <p className="text-xs font-semibold text-gray-500 uppercase dark:text-gray-400">
+                        Modelos TypeScript
+                      </p>
+                      <p className="text-sm text-gray-900 dark:text-gray-100">
+                        {module.typescriptModels.join(', ')}
+                      </p>
+                    </div>
+                    <ul className="mt-4 space-y-2 text-sm text-gray-600 dark:text-gray-300">
+                      {module.responsibilities.map((responsibility) => (
+                        <li key={responsibility} className="flex items-start space-x-2">
+                          <span className="mt-1 h-2 w-2 rounded-full bg-blue-500 dark:bg-blue-400" />
+                          <span>{responsibility}</span>
+                        </li>
+                      ))}
+                    </ul>
+                    <Button asChild variant="outline" className="mt-6 w-full">
+                      <Link href={module.dashboardPath}>Abrir Dashboard</Link>
+                    </Button>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
       </main>
     </div>
   );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Package,
   Users,
   Building,
+  Building2,
   FileText,
   Receipt,
   BarChart3,
@@ -80,7 +81,10 @@ import {
   Calculator as CalcIcon,
   Gauge,
   ShieldCheck,
-  FileBarChart2
+  FileBarChart2,
+  PackageSearch,
+  History,
+  LineChart
 } from 'lucide-react';
 import {
   Tooltip,
@@ -104,230 +108,137 @@ const menuItems: MenuItem[] = [
     icon: LayoutDashboard,
   },
   {
-    title: 'POS',
-    href: '/pos',
-    icon: ShoppingCart,
-    badge: 'Novo'
+    title: 'Core Tenancy & Shared Kernel',
+    icon: Building2,
+    children: [{ title: 'Dashboard', href: '/core-tenancy', icon: LayoutDashboard }]
   },
   {
-    title: 'Vendas',
-    icon: TrendingUp,
-    children: [
-      { title: 'Dashboard', href: '/vendas', icon: LayoutDashboard },
-      { title: 'Pedidos', href: '/vendas/pedidos', icon: ShoppingCart, badge: 'Novo' },
-      { title: 'Vendedores', href: '/vendas/vendedores', icon: Users, badge: 'Novo' },
-      { title: 'Comissões', href: '/vendas/comissoes', icon: DollarSign, badge: 'Novo' },
-      { title: 'Histórico de Vendas', href: '/vendas/historico', icon: TrendingUp },
-      { title: 'Devoluções', href: '/vendas/devolucoes', icon: RotateCcw },
-      { title: 'Trocas', href: '/vendas/trocas', icon: RefreshCw }
-    ]
-  },
-  {
-    title: 'Compras',
-    icon: ShoppingBag,
-    children: [
-      { title: 'Dashboard', href: '/compras', icon: LayoutDashboard },
-      { title: 'Pedidos de Compra', href: '/compras/pedidos', icon: ShoppingCart },
-      { title: 'Ordens de Compra', href: '/compras/ordens', icon: FileCheck }
-    ]
-  },
-  {
-    title: 'Stock',
-    icon: Package,
-    badge: 'Novo',
-    children: [
-      { title: 'Dashboard', href: '/stock', icon: LayoutDashboard },
-      { title: 'Produtos', href: '/produtos', icon: Package },
-      { title: 'Movimentação', href: '/stock/movimentacao', icon: PackageOpen },
-      { title: 'Reposição', href: '/stock/reposicao', icon: PackagePlus }
-    ]
-  },
-  {
-    title: 'Clientes',
+    title: 'CRM – Clientes',
     icon: Users,
     children: [
-      { title: 'Dashboard', href: '/clientes', icon: LayoutDashboard },
-      { title: 'Lista de Clientes', href: '/clientes/lista', icon: Users }
+      { title: 'Dashboard', href: '/clientes/dashboard', icon: LayoutDashboard },
+      { title: 'Clientes', href: '/clientes', icon: Users },
+      { title: 'Segmentação', href: '/clientes/segmentacao', icon: PieChart },
+      { title: 'Relatórios', href: '/clientes/relatorios', icon: FileText }
     ]
   },
   {
-    title: 'Fornecedores',
-    icon: Building,
+    title: 'Fornecedores & Procurement',
+    icon: PackageSearch,
     children: [
-      { title: 'Dashboard', href: '/fornecedores', icon: LayoutDashboard },
-      { title: 'Lista de Fornecedores', href: '/fornecedores/lista', icon: Building },
-      { title: 'Contas a Pagar', href: '/fornecedores/contas-pagar', icon: CreditCard }
-    ]
-  },
-  {
-    title: 'Procurement',
-    icon: ShoppingBag,
-    badge: 'Novo',
-    children: [
-      { title: 'Dashboard', href: '/procurement', icon: LayoutDashboard },
-      { title: 'Requisições de Compra', href: '/procurement/requisicoes', icon: ClipboardList },
+      { title: 'Dashboard Procurement', href: '/procurement', icon: LayoutDashboard },
+      { title: 'Dashboard Fornecedores', href: '/fornecedores/dashboard', icon: LayoutDashboard },
+      { title: 'Fornecedores', href: '/fornecedores', icon: Building },
+      { title: 'Requisições', href: '/procurement/requisicoes', icon: ClipboardList },
       { title: 'Cotações', href: '/procurement/cotacoes', icon: FileText },
-      { title: 'Pedidos de Compra', href: '/procurement/pedidos', icon: FileCheck },
-      { title: 'Recebimentos', href: '/procurement/recebimentos', icon: Truck },
-      { title: 'Aprovações', href: '/procurement/aprovacoes', icon: UserCheck }
+      { title: 'Pedidos de Compra', href: '/procurement/pedidos', icon: FileCheck }
     ]
   },
   {
-    title: 'Faturação',
-    icon: FileText,
-    children: [
-      { title: 'Dashboard', href: '/faturacao/dashboard', icon: LayoutDashboard },
-      { title: 'Faturas', href: '/faturacao', icon: Receipt },
-      { title: 'Nova Fatura', href: '/faturacao/nova', icon: FileText },
-      { title: 'Nota de Crédito', href: '/faturacao/nota-credito', icon: FileMinus },
-      { title: 'Cotações', href: '/faturacao/cotacoes', icon: FileText },
-      { title: 'Fatura Proforma', href: '/faturacao/proforma', icon: FileBarChart }
-    ]
-  },
-  {
-    title: 'Inventário',
-    icon: Archive,
-    badge: 'Novo',
+    title: 'Inventário & Ativos',
+    icon: Factory,
     children: [
       { title: 'Dashboard', href: '/inventario', icon: LayoutDashboard },
-      { title: 'Ativos', href: '/inventario/ativos', icon: Package, badge: 'Novo' },
-      { title: 'Localizações', href: '/inventario/localizacoes', icon: MapPin, badge: 'Novo' },
-      { title: 'Movimentações', href: '/inventario/movimentacoes', icon: ArrowRightLeft, badge: 'Novo' },
-      { title: 'Categorias', href: '/inventario/categorias', icon: Layers, badge: 'Novo' },
-      { title: 'Manutenção', href: '/inventario/manutencao', icon: Wrench, badge: 'Novo' },
-      { title: 'Amortização', href: '/inventario/amortizacao', icon: Calculator, badge: 'Novo' },
-      { title: 'Inventário Físico', href: '/inventario/fisico', icon: ClipboardList, badge: 'Novo' },
-      { title: 'Relatórios', href: '/inventario/relatorios', icon: FileSpreadsheet, badge: 'Novo' },
-      { title: 'Abate de Stock', href: '/inventario/abate', icon: Minus },
-      { title: 'Transferências', href: '/inventario/transferencias', icon: ArrowRightLeft },
-      { title: 'Reconciliação', href: '/inventario/reconciliacao', icon: RefreshCw }
+      { title: 'Produtos', href: '/produtos', icon: Package },
+      { title: 'Ativos', href: '/inventario/ativos', icon: Archive },
+      { title: 'Movimentações', href: '/inventario/movimentacoes', icon: ArrowRightLeft },
+      { title: 'Inventário Físico', href: '/inventario/fisico', icon: ClipboardList },
+      { title: 'Manutenção', href: '/inventario/manutencao', icon: Wrench }
     ]
   },
   {
-    title: 'Transporte',
-    icon: Truck,
-    badge: 'Novo',
+    title: 'Finanças & Contabilidade',
+    icon: Landmark,
     children: [
-      { title: 'Dashboard', href: '/transporte', icon: LayoutDashboard },
-      { title: 'Veículos', href: '/transporte/veiculos', icon: Truck },
-      { title: 'Motoristas', href: '/transporte/motoristas', icon: User },
-      { title: 'Rotas', href: '/transporte/rotas', icon: MapPin },
-      { title: 'Entregas', href: '/transporte/entregas', icon: Package },
-      { title: 'Manutenção', href: '/transporte/manutencao', icon: Wrench },
-      { title: 'Combustível', href: '/transporte/combustivel', icon: Fuel }
+      { title: 'Dashboard', href: '/contabilidade', icon: LayoutDashboard },
+      { title: 'Plano de Contas', href: '/contabilidade/plano-contas', icon: BookOpen },
+      { title: 'Lançamentos', href: '/contabilidade/lancamentos', icon: FileText },
+      { title: 'Reconciliação', href: '/contabilidade/reconciliacao', icon: Landmark },
+      { title: 'Faturação', href: '/faturacao/dashboard', icon: Receipt },
+      { title: 'Relatórios', href: '/contabilidade/dre', icon: BarChart3 }
     ]
   },
   {
-    title: 'Gestão de Projetos',
-    icon: FolderKanban,
-    badge: 'Novo',
+    title: 'Vendas & POS',
+    icon: ShoppingCart,
+    children: [
+      { title: 'Dashboard Vendas', href: '/vendas/dashboard', icon: LayoutDashboard },
+      { title: 'Pedidos', href: '/vendas/pedidos', icon: ShoppingCart },
+      { title: 'POS', href: '/pos', icon: Store },
+      { title: 'Vendedores', href: '/vendas/vendedores', icon: Users },
+      { title: 'Comissões', href: '/vendas/comissoes', icon: DollarSign },
+      { title: 'Histórico', href: '/vendas/historico', icon: History },
+      { title: 'Devoluções', href: '/vendas/devolucoes', icon: RotateCcw }
+    ]
+  },
+  {
+    title: 'Projectos',
+    icon: Briefcase,
     children: [
       { title: 'Dashboard', href: '/projetos', icon: LayoutDashboard },
       { title: 'Projetos', href: '/projetos/lista', icon: FolderKanban },
       { title: 'Tarefas', href: '/projetos/tarefas', icon: CheckSquare },
-      { title: 'Equipes', href: '/projetos/equipes', icon: Users },
       { title: 'Timesheet', href: '/projetos/timesheet', icon: Clock },
-      { title: 'Cronograma', href: '/projetos/cronograma', icon: GanttChart },
-      { title: 'Orçamentos', href: '/projetos/orcamentos', icon: Wallet },
-      { title: 'Documentos', href: '/projetos/documentos', icon: Paperclip },
       { title: 'Relatórios', href: '/projetos/relatorios', icon: FileSpreadsheet }
     ]
   },
   {
-    title: 'Gestão de Tickets',
+    title: 'Recursos Humanos & Payroll',
+    icon: UserCog,
+    children: [
+      { title: 'Dashboard', href: '/rh', icon: LayoutDashboard },
+      { title: 'Colaboradores', href: '/rh/colaboradores', icon: Users },
+      { title: 'Payroll', href: '/rh/payroll', icon: DollarSign },
+      { title: 'Férias', href: '/rh/ferias', icon: Calendar },
+      { title: 'Recrutamento', href: '/rh/recrutamento', icon: Target }
+    ]
+  },
+  {
+    title: 'Serviços & Agendamentos',
+    icon: Wrench,
+    children: [
+      { title: 'Dashboard', href: '/servicos', icon: LayoutDashboard },
+      { title: 'Lista de Serviços', href: '/servicos/lista', icon: Wrench },
+      { title: 'Agendamentos', href: '/servicos/agendamentos', icon: Calendar },
+      { title: 'Contratos', href: '/servicos/contratos', icon: FileText },
+      { title: 'Pacotes', href: '/servicos/pacotes', icon: Layers }
+    ]
+  },
+  {
+    title: 'Suporte & Tickets',
     icon: Ticket,
-    badge: 'Novo',
     children: [
       { title: 'Dashboard', href: '/tickets', icon: LayoutDashboard },
-      { title: 'Todos os Tickets', href: '/tickets/lista', icon: Ticket },
-      { title: 'Caixa de Entrada', href: '/tickets/caixa-entrada', icon: Inbox },
-      { title: 'Atribuídos a Mim', href: '/tickets/meus', icon: UserCircle },
-      { title: 'Urgentes', href: '/tickets/urgentes', icon: AlertCircle },
-      { title: 'Resolvidos', href: '/tickets/resolvidos', icon: CheckCircle },
-      { title: 'Categorias', href: '/tickets/categorias', icon: FolderOpen },
+      { title: 'Tickets', href: '/tickets/lista', icon: Ticket },
       { title: 'Base de Conhecimento', href: '/tickets/base-conhecimento', icon: BookText },
       { title: 'Relatórios', href: '/tickets/relatorios', icon: FileSpreadsheet }
     ]
   },
   {
-    title: 'Recursos Humanos',
-    icon: UserCog,
-    badge: 'Novo',
+    title: 'Transporte & Logística',
+    icon: Truck,
     children: [
-      { title: 'Dashboard', href: '/rh', icon: LayoutDashboard },
-      { title: 'Colaboradores', href: '/rh/colaboradores', icon: Users },
-      { title: 'Payroll', href: '/rh/payroll', icon: DollarSign },
-      { title: 'Plano de Férias', href: '/rh/ferias', icon: Calendar },
-      { title: 'Ausências', href: '/rh/ausencias', icon: UserX },
-      { title: 'Assiduidade', href: '/rh/assiduidade', icon: Clock },
-      { title: 'Avaliações', href: '/rh/avaliacoes', icon: Award },
-      { title: 'Formações', href: '/rh/formacoes', icon: GraduationCap },
-      { title: 'Benefícios', href: '/rh/beneficios', icon: Heart },
-      { title: 'Recrutamento', href: '/rh/recrutamento', icon: Target },
-      { title: 'Documentos', href: '/rh/documentos', icon: FileText }
+      { title: 'Dashboard', href: '/transporte', icon: LayoutDashboard },
+      { title: 'Veículos', href: '/transporte/veiculos', icon: Truck },
+      { title: 'Rotas', href: '/transporte/rotas', icon: MapPin },
+      { title: 'Manutenção', href: '/transporte/manutencao', icon: Wrench }
     ]
   },
   {
-    title: 'Produção',
+    title: 'Analytics',
+    icon: LineChart,
+    children: [{ title: 'Dashboard', href: '/analytics', icon: LayoutDashboard }]
+  },
+  {
+    title: 'Produção Industrial',
     icon: Factory,
-    badge: 'Novo',
     children: [
       { title: 'Dashboard', href: '/producao', icon: LayoutDashboard },
-      { title: 'Estrutura de Produto (BOM)', href: '/producao/estrutura', icon: Component },
-      { title: 'Roteiros de Produção', href: '/producao/roteiros', icon: Route },
       { title: 'Ordens de Produção', href: '/producao/ordens', icon: ClipboardList },
-      { title: 'Planeamento (MRP)', href: '/producao/planeamento', icon: CalcIcon },
-      { title: 'Capacidade (CRP)', href: '/producao/capacidade', icon: Gauge },
-      { title: 'Mão de Obra', href: '/producao/mao-obra', icon: Users },
-      { title: 'Custos de Produção', href: '/producao/custos', icon: DollarSign },
+      { title: 'Planeamento', href: '/producao/planeamento', icon: CalcIcon },
       { title: 'Qualidade', href: '/producao/qualidade', icon: ShieldCheck },
       { title: 'Relatórios', href: '/producao/relatorios', icon: FileBarChart2 }
     ]
-  },
-  {
-    title: 'Contabilidade',
-    icon: BookOpen,
-    badge: 'Novo',
-    children: [
-      { title: 'Dashboard', href: '/contabilidade', icon: LayoutDashboard },
-      { title: 'Plano de Contas', href: '/contabilidade/plano-contas', icon: BookOpen },
-      { title: 'Diários', href: '/contabilidade/diarios', icon: BookMarked },
-      { title: 'Razão Geral', href: '/contabilidade/razao-geral', icon: Layers },
-      { title: 'Lançamentos', href: '/contabilidade/lancamentos', icon: FileText },
-      { title: 'Centros de Custo', href: '/contabilidade/centros-custo', icon: PieChart },
-      { title: 'Reconciliação Bancária', href: '/contabilidade/reconciliacao', icon: Landmark },
-      { title: 'DRE', href: '/contabilidade/dre', icon: BarChart3 },
-      { title: 'Balancete', href: '/contabilidade/balancete', icon: FileBarChart },
-      { title: 'Configurações', href: '/contabilidade/configuracoes', icon: Cog }
-    ]
-  },
-  {
-    title: 'Caixa',
-    icon: DollarSign,
-    children: [
-      { title: 'Gestão de Caixa', href: '/caixa', icon: DollarSign },
-      { title: 'Abertura de Caixa', href: '/caixa/abertura', icon: Calculator },
-      { title: 'Fechamento de Caixa', href: '/caixa/fechamento', icon: CreditCard }
-    ]
-  },
-  {
-    title: 'Serviços',
-    icon: Wrench,
-    children: [
-      { title: 'Lista de Serviços', href: '/servicos', icon: Wrench },
-      { title: 'Categorias', href: '/servicos/categorias', icon: Layers },
-      { title: 'Novo Serviço', href: '/servicos/novo', icon: FileText }
-    ]
-  },
-  {
-    title: 'Relatórios',
-    href: '/relatorios',
-    icon: BarChart3,
-  },
-  {
-    title: 'Configurações',
-    href: '/configuracoes',
-    icon: Settings,
   }
 ];
 

--- a/src/data/system-modules.ts
+++ b/src/data/system-modules.ts
@@ -1,0 +1,284 @@
+import {
+  Building2,
+  Users,
+  Factory,
+  PackageSearch,
+  Landmark,
+  ShoppingCart,
+  Briefcase,
+  UserCog,
+  Wrench,
+  Ticket,
+  Truck,
+  LineChart,
+  LucideIcon
+} from 'lucide-react';
+
+export interface SystemModule {
+  id: string;
+  title: string;
+  description: string;
+  springModule: string;
+  typescriptModels: string[];
+  responsibilities: string[];
+  dashboardPath: string;
+  icon: LucideIcon;
+  accentColor: string;
+}
+
+export const SYSTEM_MODULES: SystemModule[] = [
+  {
+    id: 'core-tenancy',
+    title: 'Core Tenancy & Shared Kernel',
+    description: 'Gestão multi-tenant, validações fiscais e utilitários partilhados.',
+    springModule: 'core-tenancy-module, shared-kernel',
+    typescriptModels: [
+      'Tenant',
+      'Usuario',
+      'ConfiguracoesFiscais',
+      'SerieDocumento',
+      'validacao-bi.ts',
+      'provincias-mocambique.ts'
+    ],
+    responsibilities: [
+      'Gestão do tenantId e ciclo de vida dos utilizadores',
+      'Configurações fiscais e séries documentais por tenant',
+      'Validações de BI/NUIT e utilitários partilhados'
+    ],
+    dashboardPath: '/core-tenancy',
+    icon: Building2,
+    accentColor: 'bg-blue-600'
+  },
+  {
+    id: 'crm-clientes',
+    title: 'CRM – Clientes',
+    description: 'Clientes, contactos, histórico de transações e dashboards segmentados.',
+    springModule: 'crm-clientes-module',
+    typescriptModels: [
+      'Cliente',
+      'EnderecoCliente',
+      'ContactoCliente',
+      'HistoricoTransacao',
+      'DashboardClientes'
+    ],
+    responsibilities: [
+      'Gestão do agregado Cliente e contactos',
+      'Histórico e segmentação por valor e risco',
+      'Dashboards e relatórios específicos de CRM'
+    ],
+    dashboardPath: '/clientes/dashboard',
+    icon: Users,
+    accentColor: 'bg-emerald-600'
+  },
+  {
+    id: 'fornecedores-procurement',
+    title: 'Fornecedores & Procurement',
+    description: 'Abastecimento estratégico, requisições, cotações e workflows de aprovação.',
+    springModule: 'fornecedores-procurement-module',
+    typescriptModels: [
+      'Fornecedor',
+      'RequisicaoCompra',
+      'Cotacao',
+      'PedidoCompra',
+      'WorkflowAprovacao'
+    ],
+    responsibilities: [
+      'Registo e avaliação de fornecedores',
+      'Gestão de requisições, cotações e pedidos',
+      'Workflows de aprovação e relatórios de procurement'
+    ],
+    dashboardPath: '/procurement',
+    icon: PackageSearch,
+    accentColor: 'bg-purple-600'
+  },
+  {
+    id: 'inventory-assets',
+    title: 'Inventário & Ativos',
+    description: 'Catálogo de produtos, movimentações de stock e gestão de ativos.',
+    springModule: 'inventory-assets-module',
+    typescriptModels: [
+      'Produto',
+      'VarianteProduto',
+      'MovimentacaoStock',
+      'Ativo',
+      'InventarioFisico',
+      'ManutencaoAtivo'
+    ],
+    responsibilities: [
+      'Catálogo de produtos e variantes',
+      'Movimentos de stock e inventários físicos',
+      'Gestão de ativos fixos e manutenção preventiva'
+    ],
+    dashboardPath: '/inventario',
+    icon: Factory,
+    accentColor: 'bg-amber-500'
+  },
+  {
+    id: 'finance-accounting',
+    title: 'Finanças & Contabilidade',
+    description: 'Plano de contas, lançamentos e integrações com vendas/procurement.',
+    springModule: 'finance-accounting-module',
+    typescriptModels: [
+      'PlanoContas',
+      'LancamentoContabil',
+      'ReconciliacaoBancaria',
+      'ContaBancaria',
+      'DRE',
+      'Balancete'
+    ],
+    responsibilities: [
+      'Plano de contas e centros de custo',
+      'Lançamentos e reconciliações bancárias',
+      'Relatórios DRE, Balancete e automações contábeis'
+    ],
+    dashboardPath: '/contabilidade',
+    icon: Landmark,
+    accentColor: 'bg-indigo-600'
+  },
+  {
+    id: 'sales-pos',
+    title: 'Vendas & POS',
+    description: 'Fluxos POS, pedidos, validação de stock e comissões.',
+    springModule: 'sales-pos-module',
+    typescriptModels: [
+      'Pedido',
+      'ItemPedido',
+      'Venda',
+      'ComissaoVendedor',
+      'ValidacaoStock',
+      'MetodoPagamento'
+    ],
+    responsibilities: [
+      'Gestão de pedidos, vendas e POS',
+      'Cálculo de comissões por vendedor',
+      'Políticas de validação e reserva de stock'
+    ],
+    dashboardPath: '/vendas/dashboard',
+    icon: ShoppingCart,
+    accentColor: 'bg-rose-500'
+  },
+  {
+    id: 'projects',
+    title: 'Projectos',
+    description: 'Portefólio de projectos, equipas, orçamentos e milestones.',
+    springModule: 'projects-module',
+    typescriptModels: [
+      'Projeto',
+      'Tarefa',
+      'RegistroTempo',
+      'OrcamentoProjeto',
+      'DocumentoProjeto'
+    ],
+    responsibilities: [
+      'Planeamento e execução de projectos',
+      'Gestão de equipas, tarefas e tempos',
+      'Orçamentos, documentos e relatórios de progresso'
+    ],
+    dashboardPath: '/projetos',
+    icon: Briefcase,
+    accentColor: 'bg-cyan-600'
+  },
+  {
+    id: 'hr',
+    title: 'Recursos Humanos & Payroll',
+    description: 'Ciclo de vida do colaborador, ausências, formação e recrutamento.',
+    springModule: 'hr-module',
+    typescriptModels: [
+      'Colaborador',
+      'Ferias',
+      'Payroll',
+      'Avaliacao',
+      'Formacao',
+      'VagaEmprego'
+    ],
+    responsibilities: [
+      'Gestão de colaboradores, férias e ausências',
+      'Processamento salarial e benefícios',
+      'Avaliações, formação e recrutamento'
+    ],
+    dashboardPath: '/rh',
+    icon: UserCog,
+    accentColor: 'bg-teal-600'
+  },
+  {
+    id: 'services',
+    title: 'Serviços & Agendamentos',
+    description: 'Serviços, contratos, agendamentos e pacotes recorrentes.',
+    springModule: 'services-module',
+    typescriptModels: [
+      'Servico',
+      'AgendamentoServico',
+      'ContratoServico',
+      'PacoteServico',
+      'DashboardServicos'
+    ],
+    responsibilities: [
+      'Catálogo de serviços e pacotes',
+      'Agendamentos e despacho de equipas',
+      'Contratos, SLAs e dashboards de desempenho'
+    ],
+    dashboardPath: '/servicos',
+    icon: Wrench,
+    accentColor: 'bg-orange-500'
+  },
+  {
+    id: 'support-tickets',
+    title: 'Suporte & Tickets',
+    description: 'Helpdesk omnicanal com SLAs, equipas e base de conhecimento.',
+    springModule: 'support-tickets-module',
+    typescriptModels: [
+      'Ticket',
+      'AnexoTicket',
+      'EquipeSuporte',
+      'BaseConhecimento',
+      'DashboardTickets'
+    ],
+    responsibilities: [
+      'Gestão de tickets, prioridades e SLAs',
+      'Equipas de suporte e base de conhecimento',
+      'Dashboards e KPIs de atendimento'
+    ],
+    dashboardPath: '/tickets',
+    icon: Ticket,
+    accentColor: 'bg-fuchsia-600'
+  },
+  {
+    id: 'transport-logistics',
+    title: 'Transporte & Logística',
+    description: 'Frota, rotas, entregas e manutenção de veículos.',
+    springModule: 'transport-logistics-module',
+    typescriptModels: [
+      'Veiculo',
+      'Rota',
+      'Entrega',
+      'Abastecimento',
+      'Manutencao'
+    ],
+    responsibilities: [
+      'Gestão de frota, motoristas e rotas',
+      'Planeamento de entregas e tracking',
+      'Manutenção preventiva e abastecimentos'
+    ],
+    dashboardPath: '/transporte',
+    icon: Truck,
+    accentColor: 'bg-slate-600'
+  },
+  {
+    id: 'analytics',
+    title: 'Analytics',
+    description: 'Projecção de dashboards e relatórios consumindo eventos de todos os módulos.',
+    springModule: 'analytics-module',
+    typescriptModels: ['Dashboard*', 'Relatorio*'],
+    responsibilities: [
+      'Ingestão de eventos e métricas de todos os módulos',
+      'Construção de dashboards e relatórios executivos',
+      'Alertas e insights pró-ativos sobre o negócio'
+    ],
+    dashboardPath: '/analytics',
+    icon: LineChart,
+    accentColor: 'bg-pink-600'
+  }
+];
+
+export const getSystemModuleById = (id: string) =>
+  SYSTEM_MODULES.find((module) => module.id === id);


### PR DESCRIPTION
## Summary
- add a canonical bounded-context catalog (`SYSTEM_MODULES`) that maps the TypeScript models, Spring Modulith modules, and dashboard routes for every area of the ERP
- surface those bounded contexts inside the home dashboard and add new Core Tenancy and Analytics dashboards so each module has its own landing page
- reorganize the sidebar navigation so links are grouped by the new bounded contexts (core tenancy, CRM, procurement, inventory, finance, sales/POS, projects, HR, services, support, logistics, analytics, produção)

## Testing
- pnpm lint *(warnings about pre-existing missing dependency lint rules)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbcfabc788324af47edf21ca40574)