### PR TITLE
Adjust sidebar width for better visibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,7 +42,7 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
-  --sidebar-width: 240px;
+  --sidebar-width: 280px;
 }
 
 :root {


### PR DESCRIPTION
## Summary
- increase the default `--sidebar-width` custom property so sidebar menu labels are no longer truncated

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc11d63c88324bcfbb461b4f7fc1d)