### PR TITLE
Improve sidebar arrow visibility

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -326,9 +326,9 @@ export default function Sidebar() {
               </Badge>
             )}
             {isExpanded ? (
-              <ChevronDown className="ml-2 h-4 w-4 flex-shrink-0" />
+              <ChevronDown className="ml-2 h-4 w-4 flex-shrink-0 text-[#1877F2] group-hover:text-white" />
             ) : (
-              <ChevronRight className="ml-2 h-4 w-4 flex-shrink-0" />
+              <ChevronRight className="ml-2 h-4 w-4 flex-shrink-0 text-[#1877F2] group-hover:text-white" />
             )}
           </Button>
           


### PR DESCRIPTION
## Summary
- update the sidebar arrow icons so that they render with a blue foreground and switch to white on hover, ensuring they remain visible against the background

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc30bd1b88324af9d2c91e029de10)