### PR TITLE
Atualiza branding da sidebar

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -402,7 +402,7 @@ export default function Sidebar() {
         {!isCollapsed && (
           <Link href="/dashboard" className="flex items-center space-x-2">
             <Store className="h-6 w-6" />
-            <span className="text-lg font-semibold">Sistema ERP</span>
+            <span className="text-lg font-semibold">GesPro ERP</span>
           </Link>
         )}
         <Button
@@ -428,8 +428,8 @@ export default function Sidebar() {
       {!isCollapsed && (
         <div className="border-t border-border/50 p-4">
           <div className="text-xs text-muted-foreground text-center">
-            <p>Sistema ERP v1.0</p>
-            <p>© 2024 Todos os direitos reservados</p>
+            <p>GesPro ERP v1.0</p>
+            <p>© 2025 Todos os direitos reservados</p>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Atualiza o nome exibido no cabeçalho e no rodapé da sidebar para "GesPro ERP"
- Atualiza o rodapé da sidebar para exibir o ano de direitos reservados de 2025

## Testing
- Não foram executados testes automatizados; alteração apenas textual na interface

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc89b41588324b1054bff25617630)