### PR TITLE
Add requisition details view to Compras module

### DIFF
--- a/src/app/(dashboard)/compras/requisicoes/[id]/page.tsx
+++ b/src/app/(dashboard)/compras/requisicoes/[id]/page.tsx
@@ -1,0 +1,318 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import {
+  AlertCircle,
+  ArrowLeft,
+  Building2,
+  Calendar,
+  CheckCircle,
+  Clock,
+  DollarSign,
+  FileText,
+  History,
+  MessageSquare,
+  Package,
+  TrendingUp,
+  User,
+  XCircle
+} from 'lucide-react';
+import { requisicoesComprasMock } from '@/data/requisicoes-compras';
+
+const obterCorStatus = (status: string) => {
+  const cores = {
+    rascunho: 'secondary',
+    pendente: 'outline',
+    em_aprovacao: 'default',
+    aprovada: 'default',
+    rejeitada: 'destructive',
+    cancelada: 'secondary',
+    convertida: 'default'
+  } as const;
+
+  return cores[status as keyof typeof cores] || 'outline';
+};
+
+const obterIconeStatus = (status: string) => {
+  const icones = {
+    rascunho: FileText,
+    pendente: Clock,
+    em_aprovacao: AlertCircle,
+    aprovada: CheckCircle,
+    rejeitada: XCircle,
+    cancelada: XCircle,
+    convertida: TrendingUp
+  } as const;
+
+  const Icone = icones[status as keyof typeof icones] || Clock;
+  return <Icone className="h-4 w-4 mr-1" />;
+};
+
+const obterCorPrioridade = (prioridade: string) => {
+  const cores = {
+    baixa: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+    media: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+    alta: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+    urgente: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+  } as const;
+
+  return cores[prioridade as keyof typeof cores] || 'bg-gray-100 text-gray-800';
+};
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ComprasRequisicaoDetalhePage({ params }: PageProps) {
+  const { id } = await params;
+  const requisicao = requisicoesComprasMock.find((req) => req.id === id);
+
+  if (!requisicao) {
+    notFound();
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+            <Button asChild variant="ghost" size="sm" className="px-2">
+              <Link href="/compras/requisicoes" className="flex items-center gap-1">
+                <ArrowLeft className="h-4 w-4" />
+                Voltar
+              </Link>
+            </Button>
+            <span>•</span>
+            <span>Registada em {new Date(requisicao.data).toLocaleDateString('pt-MZ')}</span>
+          </div>
+          <h1 className="mt-2 text-3xl font-bold text-gray-900 dark:text-white">
+            Requisição {requisicao.numero}
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400">
+            Detalhes completos da solicitação de compra
+          </p>
+        </div>
+        <div className="flex items-center gap-4">
+          <Badge variant={obterCorStatus(requisicao.status) as any} className="flex items-center">
+            {obterIconeStatus(requisicao.status)}
+            {requisicao.status.replace('_', ' ').charAt(0).toUpperCase() + requisicao.status.replace('_', ' ').slice(1)}
+          </Badge>
+          <div className="text-right">
+            <p className="text-sm text-gray-500 dark:text-gray-400">Valor Total</p>
+            <p className="text-2xl font-bold text-green-600">
+              MT {requisicao.valorTotal.toLocaleString('pt-MZ', { minimumFractionDigits: 2 })}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardContent className="flex items-center gap-3 p-4">
+            <User className="h-10 w-10 rounded-full bg-blue-100 p-2 text-blue-600" />
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Solicitante</p>
+              <p className="font-semibold">{requisicao.solicitante}</p>
+              <p className="text-sm text-gray-500">{requisicao.departamento}</p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex items-center gap-3 p-4">
+            <Building2 className="h-10 w-10 rounded-full bg-purple-100 p-2 text-purple-600" />
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Centro de Custo</p>
+              <p className="font-semibold">{requisicao.centroCusto || '—'}</p>
+              <p className="text-sm text-gray-500">Departamento {requisicao.departamento}</p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex items-center gap-3 p-4">
+            <Calendar className="h-10 w-10 rounded-full bg-emerald-100 p-2 text-emerald-600" />
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Entrega Desejada</p>
+              <p className="font-semibold">
+                {new Date(requisicao.dataEntregaDesejada).toLocaleDateString('pt-MZ')}
+              </p>
+              <p className="text-sm text-gray-500">{requisicao.itens} itens</p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex items-center gap-3 p-4">
+            <DollarSign className="h-10 w-10 rounded-full bg-orange-100 p-2 text-orange-600" />
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Etapa de Aprovação</p>
+              <p className="font-semibold">
+                {requisicao.nivelAprovacao}/{requisicao.totalNiveis} níveis
+              </p>
+              <Badge className={obterCorPrioridade(requisicao.prioridade)}>
+                {requisicao.prioridade.charAt(0).toUpperCase() + requisicao.prioridade.slice(1)}
+              </Badge>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <FileText className="h-5 w-5" />
+              Informações Gerais
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">Número</p>
+                <p className="font-semibold">{requisicao.numero}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">Data da Solicitação</p>
+                <p className="font-semibold">
+                  {new Date(requisicao.data).toLocaleDateString('pt-MZ')}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">Departamento</p>
+                <p className="font-semibold">{requisicao.departamento}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">Situação</p>
+                <Badge variant={obterCorStatus(requisicao.status) as any} className="mt-1">
+                  {requisicao.status.replace('_', ' ').charAt(0).toUpperCase() +
+                    requisicao.status.replace('_', ' ').slice(1)}
+                </Badge>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <MessageSquare className="h-5 w-5" />
+              Justificativa e Observações
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Justificativa</p>
+              <p className="text-gray-900 dark:text-gray-100">{requisicao.justificativa}</p>
+            </div>
+            {requisicao.observacoes && (
+              <>
+                <Separator />
+                <div>
+                  <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Observações</p>
+                  <p className="text-gray-900 dark:text-gray-100">{requisicao.observacoes}</p>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Package className="h-5 w-5" />
+            Itens da Requisição ({requisicao.itensDetalhados.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Descrição</TableHead>
+                  <TableHead>Quantidade</TableHead>
+                  <TableHead>Unidade</TableHead>
+                  <TableHead>Preço Estimado</TableHead>
+                  <TableHead>Subtotal</TableHead>
+                  <TableHead>Observações</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {requisicao.itensDetalhados.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell className="font-medium">{item.descricao}</TableCell>
+                    <TableCell>{item.quantidade}</TableCell>
+                    <TableCell>{item.unidade}</TableCell>
+                    <TableCell>MT {item.precoEstimado.toLocaleString('pt-MZ', { minimumFractionDigits: 2 })}</TableCell>
+                    <TableCell className="font-semibold">
+                      MT {item.subtotal.toLocaleString('pt-MZ', { minimumFractionDigits: 2 })}
+                    </TableCell>
+                    <TableCell className="text-sm text-gray-600">
+                      {item.observacoes || '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="mt-4 flex justify-end">
+            <div className="rounded-lg bg-gray-50 p-4 text-right dark:bg-gray-900">
+              <p className="text-sm text-gray-500 dark:text-gray-400">Valor Total</p>
+              <p className="text-2xl font-bold">
+                MT {requisicao.valorTotal.toLocaleString('pt-MZ', { minimumFractionDigits: 2 })}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {requisicao.aprovacoes.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <History className="h-5 w-5" />
+              Histórico de Aprovações
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {requisicao.aprovacoes.map((aprovacao) => (
+              <div key={aprovacao.id} className="flex items-start gap-4 rounded-lg border p-4">
+                <div className="flex-shrink-0">
+                  {aprovacao.status === 'aprovado' && <CheckCircle className="h-6 w-6 text-green-600" />}
+                  {aprovacao.status === 'rejeitado' && <XCircle className="h-6 w-6 text-red-600" />}
+                  {aprovacao.status === 'pendente' && <Clock className="h-6 w-6 text-yellow-600" />}
+                </div>
+                <div className="flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-semibold">Nível {aprovacao.nivel}</p>
+                    <span className="text-sm text-gray-500">{aprovacao.aprovador} · {aprovacao.cargo}</span>
+                    <Badge variant="outline" className="ml-auto">
+                      {aprovacao.status === 'pendente' && 'Pendente'}
+                      {aprovacao.status === 'aprovado' && 'Aprovado'}
+                      {aprovacao.status === 'rejeitado' && 'Rejeitado'}
+                    </Badge>
+                  </div>
+                  <div className="mt-1 text-sm text-gray-500">
+                    {aprovacao.data
+                      ? new Date(aprovacao.data).toLocaleDateString('pt-MZ', {
+                          day: '2-digit',
+                          month: '2-digit',
+                          year: 'numeric'
+                        })
+                      : 'Sem data registrada'}
+                  </div>
+                  {aprovacao.observacoes && (
+                    <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">{aprovacao.observacoes}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/compras/requisicoes/page.tsx
+++ b/src/app/(dashboard)/compras/requisicoes/page.tsx
@@ -26,84 +26,14 @@ import {
   ChevronRight
 } from 'lucide-react';
 import { usePagination } from '@/hooks/usePagination';
+import { requisicoesComprasMock } from '@/data/requisicoes-compras';
 
 export default function ComprasRequisicoesPage() {
   const [termoPesquisa, setTermoPesquisa] = useState('');
   const [statusFiltro, setStatusFiltro] = useState('todos');
   const [prioridadeFiltro, setPrioridadeFiltro] = useState('todas');
 
-  const requisicoes = [
-    {
-      id: 'REQ-001',
-      numero: 'REQ-2024-001',
-      data: '2024-01-15',
-      solicitante: 'João Silva',
-      departamento: 'TI',
-      prioridade: 'alta',
-      status: 'em_aprovacao',
-      itens: 5,
-      valorTotal: 45000.00,
-      dataEntregaDesejada: '2024-02-01',
-      nivelAprovacao: 2,
-      totalNiveis: 3
-    },
-    {
-      id: 'REQ-002',
-      numero: 'REQ-2024-002',
-      data: '2024-01-14',
-      solicitante: 'Maria Santos',
-      departamento: 'Compras',
-      prioridade: 'media',
-      status: 'aprovada',
-      itens: 3,
-      valorTotal: 12500.00,
-      dataEntregaDesejada: '2024-01-25',
-      nivelAprovacao: 3,
-      totalNiveis: 3
-    },
-    {
-      id: 'REQ-003',
-      numero: 'REQ-2024-003',
-      data: '2024-01-13',
-      solicitante: 'Pedro Costa',
-      departamento: 'Manutenção',
-      prioridade: 'urgente',
-      status: 'pendente',
-      itens: 8,
-      valorTotal: 8900.00,
-      dataEntregaDesejada: '2024-01-20',
-      nivelAprovacao: 0,
-      totalNiveis: 2
-    },
-    {
-      id: 'REQ-004',
-      numero: 'REQ-2024-004',
-      data: '2024-01-12',
-      solicitante: 'Ana Oliveira',
-      departamento: 'Administrativo',
-      prioridade: 'baixa',
-      status: 'rejeitada',
-      itens: 2,
-      valorTotal: 3200.00,
-      dataEntregaDesejada: '2024-02-10',
-      nivelAprovacao: 1,
-      totalNiveis: 2
-    },
-    {
-      id: 'REQ-005',
-      numero: 'REQ-2024-005',
-      data: '2024-01-11',
-      solicitante: 'Carlos Mendes',
-      departamento: 'Produção',
-      prioridade: 'alta',
-      status: 'convertida',
-      itens: 12,
-      valorTotal: 67800.00,
-      dataEntregaDesejada: '2024-01-30',
-      nivelAprovacao: 3,
-      totalNiveis: 3
-    }
-  ];
+  const requisicoes = requisicoesComprasMock;
 
   const requisicoesFiltradas = requisicoes.filter(req => {
     const correspondeNome = req.numero.toLowerCase().includes(termoPesquisa.toLowerCase()) ||

--- a/src/data/requisicoes-compras.ts
+++ b/src/data/requisicoes-compras.ts
@@ -1,0 +1,408 @@
+export type StatusRequisicaoCompra =
+  | 'rascunho'
+  | 'pendente'
+  | 'em_aprovacao'
+  | 'aprovada'
+  | 'rejeitada'
+  | 'cancelada'
+  | 'convertida';
+
+export type PrioridadeRequisicao = 'baixa' | 'media' | 'alta' | 'urgente';
+
+export interface ItemRequisicaoDetalhado {
+  id: string;
+  descricao: string;
+  quantidade: number;
+  unidade: string;
+  precoEstimado: number;
+  subtotal: number;
+  observacoes?: string;
+}
+
+export interface AprovacaoRequisicao {
+  id: string;
+  nivel: number;
+  aprovador: string;
+  cargo: string;
+  status: 'pendente' | 'aprovado' | 'rejeitado';
+  data?: string;
+  observacoes?: string;
+}
+
+export interface RequisicaoComprasDetalhada {
+  id: string;
+  numero: string;
+  data: string;
+  solicitante: string;
+  departamento: string;
+  prioridade: PrioridadeRequisicao;
+  status: StatusRequisicaoCompra;
+  itens: number;
+  valorTotal: number;
+  dataEntregaDesejada: string;
+  nivelAprovacao: number;
+  totalNiveis: number;
+  justificativa: string;
+  observacoes?: string;
+  centroCusto?: string;
+  itensDetalhados: ItemRequisicaoDetalhado[];
+  aprovacoes: AprovacaoRequisicao[];
+}
+
+export const requisicoesComprasMock: RequisicaoComprasDetalhada[] = [
+  {
+    id: 'REQ-001',
+    numero: 'REQ-2024-001',
+    data: '2024-01-15',
+    solicitante: 'João Silva',
+    departamento: 'TI',
+    prioridade: 'alta',
+    status: 'em_aprovacao',
+    itens: 5,
+    valorTotal: 45000,
+    dataEntregaDesejada: '2024-02-01',
+    nivelAprovacao: 2,
+    totalNiveis: 3,
+    justificativa:
+      'Atualização das licenças de software corporativo para suportar a expansão da equipa de desenvolvimento.',
+    observacoes: 'Prioridade para instalação até o final de janeiro.',
+    centroCusto: 'TI-001',
+    itensDetalhados: [
+      {
+        id: 'REQ-001-ITEM-1',
+        descricao: 'Licenças Microsoft 365 Business',
+        quantidade: 30,
+        unidade: 'un',
+        precoEstimado: 350,
+        subtotal: 10500,
+        observacoes: 'Plano Business Standard'
+      },
+      {
+        id: 'REQ-001-ITEM-2',
+        descricao: 'Assinaturas GitHub Enterprise',
+        quantidade: 15,
+        unidade: 'un',
+        precoEstimado: 420,
+        subtotal: 6300
+      },
+      {
+        id: 'REQ-001-ITEM-3',
+        descricao: 'Serviço de backup em nuvem',
+        quantidade: 1,
+        unidade: 'pacote',
+        precoEstimado: 12000,
+        subtotal: 12000,
+        observacoes: 'Contrato anual'
+      },
+      {
+        id: 'REQ-001-ITEM-4',
+        descricao: 'Licenças Jira Software',
+        quantidade: 20,
+        unidade: 'un',
+        precoEstimado: 280,
+        subtotal: 5600
+      },
+      {
+        id: 'REQ-001-ITEM-5',
+        descricao: 'Serviço de suporte técnico',
+        quantidade: 1,
+        unidade: 'pacote',
+        precoEstimado: 10600,
+        subtotal: 10600
+      }
+    ],
+    aprovacoes: [
+      {
+        id: 'REQ-001-APR-1',
+        nivel: 1,
+        aprovador: 'Carlos Pereira',
+        cargo: 'Gestor de TI',
+        status: 'aprovado',
+        data: '2024-01-16',
+        observacoes: 'Alinhado com o plano estratégico de TI.'
+      },
+      {
+        id: 'REQ-001-APR-2',
+        nivel: 2,
+        aprovador: 'Helena Matos',
+        cargo: 'Diretora Financeira',
+        status: 'pendente'
+      },
+      {
+        id: 'REQ-001-APR-3',
+        nivel: 3,
+        aprovador: 'Jorge Manjate',
+        cargo: 'CEO',
+        status: 'pendente'
+      }
+    ]
+  },
+  {
+    id: 'REQ-002',
+    numero: 'REQ-2024-002',
+    data: '2024-01-14',
+    solicitante: 'Maria Santos',
+    departamento: 'Compras',
+    prioridade: 'media',
+    status: 'aprovada',
+    itens: 3,
+    valorTotal: 12500,
+    dataEntregaDesejada: '2024-01-25',
+    nivelAprovacao: 3,
+    totalNiveis: 3,
+    justificativa: 'Reposição do stock mínimo de equipamentos de escritório para novas contratações.',
+    observacoes: 'Itens devem ser entregues no escritório central.',
+    centroCusto: 'ADM-002',
+    itensDetalhados: [
+      {
+        id: 'REQ-002-ITEM-1',
+        descricao: 'Cadeiras ergonómicas',
+        quantidade: 10,
+        unidade: 'un',
+        precoEstimado: 450,
+        subtotal: 4500
+      },
+      {
+        id: 'REQ-002-ITEM-2',
+        descricao: 'Secretárias ajustáveis',
+        quantidade: 5,
+        unidade: 'un',
+        precoEstimado: 850,
+        subtotal: 4250
+      },
+      {
+        id: 'REQ-002-ITEM-3',
+        descricao: 'Monitores 27"',
+        quantidade: 5,
+        unidade: 'un',
+        precoEstimado: 750,
+        subtotal: 3750
+      }
+    ],
+    aprovacoes: [
+      {
+        id: 'REQ-002-APR-1',
+        nivel: 1,
+        aprovador: 'André Timana',
+        cargo: 'Coordenador Administrativo',
+        status: 'aprovado',
+        data: '2024-01-15'
+      },
+      {
+        id: 'REQ-002-APR-2',
+        nivel: 2,
+        aprovador: 'Helena Matos',
+        cargo: 'Diretora Financeira',
+        status: 'aprovado',
+        data: '2024-01-16'
+      },
+      {
+        id: 'REQ-002-APR-3',
+        nivel: 3,
+        aprovador: 'Jorge Manjate',
+        cargo: 'CEO',
+        status: 'aprovado',
+        data: '2024-01-17'
+      }
+    ]
+  },
+  {
+    id: 'REQ-003',
+    numero: 'REQ-2024-003',
+    data: '2024-01-13',
+    solicitante: 'Pedro Costa',
+    departamento: 'Manutenção',
+    prioridade: 'urgente',
+    status: 'pendente',
+    itens: 8,
+    valorTotal: 8900,
+    dataEntregaDesejada: '2024-01-20',
+    nivelAprovacao: 0,
+    totalNiveis: 2,
+    justificativa:
+      'Reposição imediata de peças críticas para evitar paralisação da linha de produção.',
+    observacoes: 'Solicitar transporte expresso.',
+    centroCusto: 'MAN-008',
+    itensDetalhados: [
+      {
+        id: 'REQ-003-ITEM-1',
+        descricao: 'Correias industriais',
+        quantidade: 4,
+        unidade: 'pc',
+        precoEstimado: 650,
+        subtotal: 2600
+      },
+      {
+        id: 'REQ-003-ITEM-2',
+        descricao: 'Sensores de temperatura',
+        quantidade: 6,
+        unidade: 'pc',
+        precoEstimado: 450,
+        subtotal: 2700
+      },
+      {
+        id: 'REQ-003-ITEM-3',
+        descricao: 'Kit de lubrificação',
+        quantidade: 5,
+        unidade: 'pc',
+        precoEstimado: 300,
+        subtotal: 1500
+      },
+      {
+        id: 'REQ-003-ITEM-4',
+        descricao: 'Rolamentos',
+        quantidade: 10,
+        unidade: 'pc',
+        precoEstimado: 210,
+        subtotal: 2100
+      }
+    ],
+    aprovacoes: [
+      {
+        id: 'REQ-003-APR-1',
+        nivel: 1,
+        aprovador: 'Samuel Zimba',
+        cargo: 'Supervisor de Manutenção',
+        status: 'pendente'
+      },
+      {
+        id: 'REQ-003-APR-2',
+        nivel: 2,
+        aprovador: 'Helena Matos',
+        cargo: 'Diretora Financeira',
+        status: 'pendente'
+      }
+    ]
+  },
+  {
+    id: 'REQ-004',
+    numero: 'REQ-2024-004',
+    data: '2024-01-12',
+    solicitante: 'Ana Oliveira',
+    departamento: 'Administrativo',
+    prioridade: 'baixa',
+    status: 'rejeitada',
+    itens: 2,
+    valorTotal: 3200,
+    dataEntregaDesejada: '2024-02-10',
+    nivelAprovacao: 1,
+    totalNiveis: 2,
+    justificativa: 'Aquisição de mobiliário adicional para a sala de reuniões secundária.',
+    observacoes: 'Pode ser reavaliado no próximo trimestre.',
+    centroCusto: 'ADM-005',
+    itensDetalhados: [
+      {
+        id: 'REQ-004-ITEM-1',
+        descricao: 'Mesa de reuniões 10 lugares',
+        quantidade: 1,
+        unidade: 'un',
+        precoEstimado: 2200,
+        subtotal: 2200
+      },
+      {
+        id: 'REQ-004-ITEM-2',
+        descricao: 'Painel interativo 65"',
+        quantidade: 1,
+        unidade: 'un',
+        precoEstimado: 1000,
+        subtotal: 1000
+      }
+    ],
+    aprovacoes: [
+      {
+        id: 'REQ-004-APR-1',
+        nivel: 1,
+        aprovador: 'André Timana',
+        cargo: 'Coordenador Administrativo',
+        status: 'rejeitado',
+        data: '2024-01-13',
+        observacoes: 'Priorizar investimentos em infraestrutura principal.'
+      },
+      {
+        id: 'REQ-004-APR-2',
+        nivel: 2,
+        aprovador: 'Helena Matos',
+        cargo: 'Diretora Financeira',
+        status: 'pendente'
+      }
+    ]
+  },
+  {
+    id: 'REQ-005',
+    numero: 'REQ-2024-005',
+    data: '2024-01-11',
+    solicitante: 'Carlos Mendes',
+    departamento: 'Produção',
+    prioridade: 'alta',
+    status: 'convertida',
+    itens: 12,
+    valorTotal: 67800,
+    dataEntregaDesejada: '2024-01-30',
+    nivelAprovacao: 3,
+    totalNiveis: 3,
+    justificativa:
+      'Compra de matéria-prima para garantir a produção do novo lote de equipamentos.',
+    observacoes: 'Pedido já convertido em ordem de compra #PO-2024-087.',
+    centroCusto: 'PRO-004',
+    itensDetalhados: [
+      {
+        id: 'REQ-005-ITEM-1',
+        descricao: 'Bobinas de aço galvanizado',
+        quantidade: 20,
+        unidade: 'ton',
+        precoEstimado: 1500,
+        subtotal: 30000
+      },
+      {
+        id: 'REQ-005-ITEM-2',
+        descricao: 'Componentes eletrónicos diversos',
+        quantidade: 50,
+        unidade: 'caixa',
+        precoEstimado: 250,
+        subtotal: 12500
+      },
+      {
+        id: 'REQ-005-ITEM-3',
+        descricao: 'Cablagem industrial',
+        quantidade: 100,
+        unidade: 'rolo',
+        precoEstimado: 110,
+        subtotal: 11000
+      },
+      {
+        id: 'REQ-005-ITEM-4',
+        descricao: 'Serviços de transporte especializado',
+        quantidade: 1,
+        unidade: 'pacote',
+        precoEstimado: 14300,
+        subtotal: 14300
+      }
+    ],
+    aprovacoes: [
+      {
+        id: 'REQ-005-APR-1',
+        nivel: 1,
+        aprovador: 'Samuel Zimba',
+        cargo: 'Supervisor de Produção',
+        status: 'aprovado',
+        data: '2024-01-12'
+      },
+      {
+        id: 'REQ-005-APR-2',
+        nivel: 2,
+        aprovador: 'Helena Matos',
+        cargo: 'Diretora Financeira',
+        status: 'aprovado',
+        data: '2024-01-13'
+      },
+      {
+        id: 'REQ-005-APR-3',
+        nivel: 3,
+        aprovador: 'Jorge Manjate',
+        cargo: 'CEO',
+        status: 'aprovado',
+        data: '2024-01-14'
+      }
+    ]
+  }
+];


### PR DESCRIPTION
## Summary
- add a shared mock dataset with detailed requisition information for the Compras area
- update the requisitions listing to consume the shared dataset
- create the requisition detail page so the "View" action surfaces complete requisition information

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ccd6a2be0832494ce98713ab1fc63)