### PR TITLE
fix: rotas 404 consolidadas (10 formulários de criação + proforma real + /contactos)

### DIFF
--- a/apps/erp/middleware.ts
+++ b/apps/erp/middleware.ts
@@ -26,6 +26,8 @@ const PUBLIC_PATHS = [
   // Callback de handoff site→app: valida o token e estabelece a sessão. Já
   // coberto pelo prefixo '/auth/', listado por ser contrato com a spec 18.
   '/auth/registo-callback',
+  // Página pública de contacto/suporte, ligada a partir do ecrã de login.
+  '/contactos',
   '/_next/',
   '/favicon.ico',
 ];

--- a/apps/erp/src/app/(auth)/contactos/page.tsx
+++ b/apps/erp/src/app/(auth)/contactos/page.tsx
@@ -1,0 +1,70 @@
+/**
+ * Página pública de contacto/suporte — acessível sem sessão (ligada a partir do
+ * ecrã de login). Não fabrica contactos específicos: a orientação real para um
+ * ERP multi-tenant é o utilizador contactar o administrador da sua organização.
+ * O owner pode preencher canais concretos (email/telefone) quando os definir.
+ */
+
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { ArrowLeft, Building2, LifeBuoy, Mail } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+export const metadata: Metadata = {
+  title: 'Contacto e Suporte',
+  description: 'Como obter ajuda com o acesso e utilização do GestPro.',
+};
+
+export default function ContactosPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6 bg-muted/30">
+      <div className="w-full max-w-2xl space-y-6">
+        <div className="space-y-2 text-center">
+          <h1 className="text-2xl font-bold">Contacto e Suporte</h1>
+          <p className="text-muted-foreground">
+            Estamos aqui para ajudar. Escolha o canal adequado à sua questão.
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center gap-3">
+            <Building2 className="h-5 w-5 text-primary" aria-hidden />
+            <CardTitle className="text-base">Acesso à conta</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Para recuperar credenciais, obter um convite ou alterar permissões,
+            contacte o <strong className="text-foreground">administrador da sua organização</strong>.
+            É quem gere os utilizadores e os acessos do vosso espaço no GestPro.
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center gap-3">
+            <LifeBuoy className="h-5 w-5 text-primary" aria-hidden />
+            <CardTitle className="text-base">Suporte técnico</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground space-y-2">
+            <p>
+              Para incidentes técnicos ou dúvidas de utilização, o administrador da
+              sua organização encaminha o pedido para a equipa de suporte do GestPro.
+            </p>
+            <p className="flex items-center gap-2">
+              <Mail className="h-4 w-4" aria-hidden />
+              <span>Canal de suporte a definir pela organização.</span>
+            </p>
+          </CardContent>
+        </Card>
+
+        <div className="text-center">
+          <Button asChild variant="ghost">
+            <Link href="/auth/login">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Voltar ao início de sessão
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/compras/cotacoes/novo/_components/nova-cotacao-form.tsx
+++ b/apps/erp/src/app/(dashboard)/compras/cotacoes/novo/_components/nova-cotacao-form.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Plus, Trash2, Save, X, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { criarCotacaoAction } from '@/server/actions/compras.actions';
+
+const ItemFormSchema = z.object({
+  descricao: z.string().min(1, 'Descrição obrigatória'),
+  quantidade: z.coerce.number().positive('Quantidade positiva'),
+  unidadeMedida: z.string().min(1, 'Unidade obrigatória'),
+  especificacoes: z.string().optional(),
+});
+
+const FormSchema = z.object({
+  dataValidade: z.string().min(1, 'Data de validade obrigatória'),
+  requisicaoCompraId: z.string().optional(),
+  fornecedoresIds: z.string().optional(),
+  observacoes: z.string().optional(),
+  itens: z.array(ItemFormSchema).min(1, 'Mínimo 1 item'),
+});
+
+type FormValues = z.infer<typeof FormSchema>;
+
+export function NovaCotacaoForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      dataValidade: '',
+      requisicaoCompraId: '',
+      fornecedoresIds: '',
+      observacoes: '',
+      itens: [{ descricao: '', quantidade: 1, unidadeMedida: 'un', especificacoes: '' }],
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({ control, name: 'itens' });
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const fornecedoresIds = (values.fornecedoresIds ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+      const result = await criarCotacaoAction({
+        dataValidade: values.dataValidade,
+        requisicaoCompraId: values.requisicaoCompraId || undefined,
+        fornecedoresIds: fornecedoresIds.length > 0 ? fornecedoresIds : undefined,
+        observacoes: values.observacoes || undefined,
+        itens: values.itens.map((it) => ({
+          descricao: it.descricao,
+          quantidade: Number(it.quantidade),
+          unidadeMedida: it.unidadeMedida,
+          especificacoes: it.especificacoes || undefined,
+        })),
+      } as any);
+
+      if (result?.ok) {
+        toast.success('Cotação criada com sucesso.');
+        router.push('/compras/cotacoes');
+      } else {
+        toast.error((result as any)?.error?.message ?? 'Erro ao criar cotação.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/compras/cotacoes')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A criar…' : 'Criar Cotação'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Dados da Cotação" description="Prazo de validade e origem do pedido de cotação">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="data-validade">Data de Validade *</Label>
+              <Input id="data-validade" type="date" {...register('dataValidade')} />
+              {errors.dataValidade && (
+                <p className="text-sm text-destructive">{errors.dataValidade.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="requisicao-id">ID da Requisição de Compra</Label>
+              <Input
+                id="requisicao-id"
+                {...register('requisicaoCompraId')}
+                placeholder="ID da requisição (CUID) — opcional"
+              />
+              <p className="text-xs text-muted-foreground">Pesquisa disponível após integração comercial.</p>
+              {errors.requisicaoCompraId && (
+                <p className="text-sm text-destructive">{errors.requisicaoCompraId.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="fornecedores-ids">IDs de Fornecedores a Convidar</Label>
+            <Input
+              id="fornecedores-ids"
+              {...register('fornecedoresIds')}
+              placeholder="IDs separados por vírgula (CUID) — opcional"
+            />
+            <p className="text-xs text-muted-foreground">Pesquisa de fornecedores disponível após integração comercial.</p>
+          </div>
+        </FormSection>
+
+        <FormSection title="Itens da Cotação" description="Produtos ou serviços a cotar">
+          <div className="hidden md:grid grid-cols-12 gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
+            <span className="col-span-4">Descrição</span>
+            <span className="col-span-2">Qtd</span>
+            <span className="col-span-2">Unidade</span>
+            <span className="col-span-3">Especificações</span>
+            <span className="col-span-1"></span>
+          </div>
+
+          {fields.map((field, i) => (
+            <div key={field.id} className="grid grid-cols-12 gap-2 items-start">
+              <div className="col-span-12 md:col-span-4 space-y-1">
+                <Label className="md:hidden text-xs" htmlFor={`item-descricao-${i}`}>Descrição *</Label>
+                <Input
+                  id={`item-descricao-${i}`}
+                  {...register(`itens.${i}.descricao`)}
+                  placeholder="Descrição do produto/serviço"
+                  aria-label={`Descrição do item ${i + 1}`}
+                />
+                {errors.itens?.[i]?.descricao && (
+                  <p className="text-xs text-destructive">{errors.itens[i]?.descricao?.message}</p>
+                )}
+              </div>
+              <div className="col-span-4 md:col-span-2 space-y-1">
+                <Label className="md:hidden text-xs">Qtd</Label>
+                <Input
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  {...register(`itens.${i}.quantidade`)}
+                  aria-label={`Quantidade item ${i + 1}`}
+                />
+              </div>
+              <div className="col-span-4 md:col-span-2 space-y-1">
+                <Label className="md:hidden text-xs">Unidade</Label>
+                <Input
+                  {...register(`itens.${i}.unidadeMedida`)}
+                  placeholder="un"
+                  aria-label={`Unidade item ${i + 1}`}
+                />
+                {errors.itens?.[i]?.unidadeMedida && (
+                  <p className="text-xs text-destructive">{errors.itens[i]?.unidadeMedida?.message}</p>
+                )}
+              </div>
+              <div className="col-span-8 md:col-span-3 space-y-1">
+                <Label className="md:hidden text-xs">Especificações</Label>
+                <Input
+                  {...register(`itens.${i}.especificacoes`)}
+                  placeholder="Especificações (opcional)"
+                  aria-label={`Especificações item ${i + 1}`}
+                />
+              </div>
+              <div className="col-span-4 md:col-span-1 flex items-start pt-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  disabled={fields.length === 1}
+                  onClick={() => remove(i)}
+                  aria-label="Remover item"
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </div>
+            </div>
+          ))}
+
+          {errors.itens?.root && (
+            <p className="text-sm text-destructive flex items-center gap-1">
+              <AlertCircle className="h-4 w-4" />
+              {errors.itens.root.message}
+            </p>
+          )}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => append({ descricao: '', quantidade: 1, unidadeMedida: 'un', especificacoes: '' })}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Adicionar item
+          </Button>
+        </FormSection>
+
+        <FormSection title="Observações" description="Notas adicionais para os fornecedores">
+          <Textarea
+            {...register('observacoes')}
+            placeholder="Observações adicionais (opcional)…"
+            rows={3}
+          />
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/compras/cotacoes/novo/page.tsx
+++ b/apps/erp/src/app/(dashboard)/compras/cotacoes/novo/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * Nova Cotação (RFQ) — Server Component shell.
+ */
+
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { PageHeader } from '@/components/patterns';
+import { NovaCotacaoForm } from './_components/nova-cotacao-form';
+
+export default async function NovaCotacaoPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+
+  return (
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Nova Cotação"
+        description="Pedido de cotação (RFQ) a fornecedores"
+        breadcrumbs={[
+          { label: 'Compras', href: '/compras' },
+          { label: 'Cotações', href: '/compras/cotacoes' },
+          { label: 'Nova Cotação' },
+        ]}
+      />
+      <NovaCotacaoForm />
+    </div>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/compras/pedidos/novo/_components/novo-pedido-form.tsx
+++ b/apps/erp/src/app/(dashboard)/compras/pedidos/novo/_components/novo-pedido-form.tsx
@@ -1,0 +1,368 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm, useFieldArray, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Plus, Trash2, Save, X, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { criarPedidoCompraAction } from '@/server/actions/compras.actions';
+
+const ItemFormSchema = z.object({
+  descricao: z.string().min(1, 'Descrição obrigatória'),
+  quantidade: z.coerce.number().positive('Quantidade positiva'),
+  unidadeMedida: z.string().min(1, 'Unidade obrigatória'),
+  precoUnitario: z.coerce.number().positive('Preço positivo'),
+  desconto: z.coerce.number().nonnegative().default(0),
+  taxaIva: z.coerce.number().default(0.16),
+  observacoes: z.string().optional(),
+});
+
+const FormSchema = z.object({
+  fornecedorId: z.string().min(1, 'Fornecedor obrigatório'),
+  data: z.string().min(1, 'Data obrigatória'),
+  condicoesPagamento: z.string().min(1, 'Condições de pagamento obrigatórias'),
+  prazoEntregaDias: z.coerce.number().int().positive('Prazo positivo'),
+  dataEntregaPrevista: z.string().min(1, 'Data prevista obrigatória'),
+  enderecoEntrega: z.string().min(1, 'Endereço de entrega obrigatório'),
+  centroCustoId: z.string().optional(),
+  requisicaoCompraId: z.string().optional(),
+  cotacaoId: z.string().optional(),
+  observacoes: z.string().optional(),
+  itens: z.array(ItemFormSchema).min(1, 'Mínimo 1 item'),
+});
+
+type FormValues = z.infer<typeof FormSchema>;
+
+const today = new Date().toISOString().split('T')[0];
+
+export function NovoPedidoForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    setValue,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      fornecedorId: '',
+      data: today,
+      condicoesPagamento: '',
+      prazoEntregaDias: 30,
+      dataEntregaPrevista: '',
+      enderecoEntrega: '',
+      centroCustoId: '',
+      requisicaoCompraId: '',
+      cotacaoId: '',
+      observacoes: '',
+      itens: [{ descricao: '', quantidade: 1, unidadeMedida: 'un', precoUnitario: 0, desconto: 0, taxaIva: 0.16 }],
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({ control, name: 'itens' });
+  const itens = useWatch({ control, name: 'itens' }) ?? [];
+
+  const totais = itens.reduce(
+    (acc, l) => {
+      const q = Number(l.quantidade) || 0;
+      const p = Number(l.precoUnitario) || 0;
+      const d = Number(l.desconto) || 0;
+      const taxa = Number(l.taxaIva) || 0;
+      const base = q * p - d;
+      const iva = base * taxa;
+      return { subtotal: acc.subtotal + base, iva: acc.iva + iva, total: acc.total + base + iva };
+    },
+    { subtotal: 0, iva: 0, total: 0 }
+  );
+
+  const fmtMZN = new Intl.NumberFormat('pt-MZ', { style: 'currency', currency: 'MZN' });
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const result = await criarPedidoCompraAction({
+        fornecedorId: values.fornecedorId,
+        data: values.data,
+        condicoesPagamento: values.condicoesPagamento,
+        prazoEntregaDias: Number(values.prazoEntregaDias),
+        dataEntregaPrevista: values.dataEntregaPrevista,
+        enderecoEntrega: values.enderecoEntrega,
+        centroCustoId: values.centroCustoId || undefined,
+        requisicaoCompraId: values.requisicaoCompraId || undefined,
+        cotacaoId: values.cotacaoId || undefined,
+        observacoes: values.observacoes || undefined,
+        itens: values.itens.map((it) => ({
+          descricao: it.descricao,
+          quantidade: Number(it.quantidade),
+          unidadeMedida: it.unidadeMedida,
+          precoUnitario: Number(it.precoUnitario),
+          desconto: Number(it.desconto) || 0,
+          taxaIva: Number(it.taxaIva) || 0.16,
+          observacoes: it.observacoes || undefined,
+        })),
+      } as any);
+
+      if (result?.ok) {
+        toast.success('Pedido de compra criado com sucesso.');
+        router.push('/compras/pedidos');
+      } else {
+        toast.error((result as any)?.error?.message ?? 'Erro ao criar pedido de compra.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/compras/pedidos')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A criar…' : 'Criar Pedido'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Fornecedor e Condições" description="Dados do fornecedor e condições comerciais">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="fornecedor-id">ID do Fornecedor *</Label>
+              <Input id="fornecedor-id" {...register('fornecedorId')} placeholder="ID do fornecedor (CUID)" />
+              <p className="text-xs text-muted-foreground">Pesquisa de fornecedores disponível após integração comercial.</p>
+              {errors.fornecedorId && (
+                <p className="text-sm text-destructive">{errors.fornecedorId.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="data">Data do Pedido *</Label>
+              <Input id="data" type="date" {...register('data')} />
+              {errors.data && <p className="text-sm text-destructive">{errors.data.message}</p>}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="condicoes-pagamento">Condições de Pagamento *</Label>
+              <Input
+                id="condicoes-pagamento"
+                {...register('condicoesPagamento')}
+                placeholder="ex.: 30 dias após factura"
+              />
+              {errors.condicoesPagamento && (
+                <p className="text-sm text-destructive">{errors.condicoesPagamento.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="prazo-entrega">Prazo de Entrega (dias) *</Label>
+              <Input id="prazo-entrega" type="number" min="1" step="1" {...register('prazoEntregaDias')} />
+              {errors.prazoEntregaDias && (
+                <p className="text-sm text-destructive">{errors.prazoEntregaDias.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="data-entrega-prevista">Data de Entrega Prevista *</Label>
+              <Input id="data-entrega-prevista" type="date" {...register('dataEntregaPrevista')} />
+              {errors.dataEntregaPrevista && (
+                <p className="text-sm text-destructive">{errors.dataEntregaPrevista.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="centro-custo-id">ID do Centro de Custo</Label>
+              <Input
+                id="centro-custo-id"
+                {...register('centroCustoId')}
+                placeholder="ID do centro de custo (CUID) — opcional"
+              />
+              <p className="text-xs text-muted-foreground">Pesquisa disponível após integração comercial.</p>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="endereco-entrega">Endereço de Entrega *</Label>
+            <Textarea id="endereco-entrega" {...register('enderecoEntrega')} rows={2} placeholder="Morada de entrega da encomenda" />
+            {errors.enderecoEntrega && (
+              <p className="text-sm text-destructive">{errors.enderecoEntrega.message}</p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="requisicao-id">ID da Requisição de Compra</Label>
+              <Input
+                id="requisicao-id"
+                {...register('requisicaoCompraId')}
+                placeholder="ID da requisição (CUID) — opcional"
+              />
+              <p className="text-xs text-muted-foreground">Pesquisa disponível após integração comercial.</p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cotacao-id">ID da Cotação</Label>
+              <Input
+                id="cotacao-id"
+                {...register('cotacaoId')}
+                placeholder="ID da cotação (CUID) — opcional"
+              />
+              <p className="text-xs text-muted-foreground">Pesquisa disponível após integração comercial.</p>
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection title="Itens do Pedido" description="Produtos ou serviços a encomendar">
+          <div className="hidden md:grid grid-cols-12 gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
+            <span className="col-span-3">Descrição</span>
+            <span className="col-span-1">Qtd</span>
+            <span className="col-span-2">Unidade</span>
+            <span className="col-span-2">Preço Unit.</span>
+            <span className="col-span-1">Desc.</span>
+            <span className="col-span-1">IVA %</span>
+            <span className="col-span-1 text-right">Total</span>
+            <span className="col-span-1"></span>
+          </div>
+
+          {fields.map((field, i) => {
+            const q = Number(itens[i]?.quantidade) || 0;
+            const p = Number(itens[i]?.precoUnitario) || 0;
+            const d = Number(itens[i]?.desconto) || 0;
+            const taxa = Number(itens[i]?.taxaIva) || 0;
+            const base = q * p - d;
+            const total = base + base * taxa;
+
+            return (
+              <div key={field.id} className="grid grid-cols-12 gap-2 items-start">
+                <div className="col-span-12 md:col-span-3 space-y-1">
+                  <Label className="md:hidden text-xs" htmlFor={`item-descricao-${i}`}>Descrição *</Label>
+                  <Input
+                    id={`item-descricao-${i}`}
+                    {...register(`itens.${i}.descricao`)}
+                    placeholder="Descrição do produto/serviço"
+                    aria-label={`Descrição do item ${i + 1}`}
+                  />
+                  {errors.itens?.[i]?.descricao && (
+                    <p className="text-xs text-destructive">{errors.itens[i]?.descricao?.message}</p>
+                  )}
+                </div>
+                <div className="col-span-4 md:col-span-1 space-y-1">
+                  <Label className="md:hidden text-xs">Qtd</Label>
+                  <Input type="number" min="0.01" step="0.01" {...register(`itens.${i}.quantidade`)} aria-label={`Quantidade item ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-2 space-y-1">
+                  <Label className="md:hidden text-xs">Unidade</Label>
+                  <Input {...register(`itens.${i}.unidadeMedida`)} placeholder="un" aria-label={`Unidade item ${i + 1}`} />
+                  {errors.itens?.[i]?.unidadeMedida && (
+                    <p className="text-xs text-destructive">{errors.itens[i]?.unidadeMedida?.message}</p>
+                  )}
+                </div>
+                <div className="col-span-4 md:col-span-2 space-y-1">
+                  <Label className="md:hidden text-xs">Preço</Label>
+                  <Input type="number" min="0" step="0.01" {...register(`itens.${i}.precoUnitario`)} aria-label={`Preço unitário item ${i + 1}`} />
+                  {errors.itens?.[i]?.precoUnitario && (
+                    <p className="text-xs text-destructive">{errors.itens[i]?.precoUnitario?.message}</p>
+                  )}
+                </div>
+                <div className="col-span-4 md:col-span-1 space-y-1">
+                  <Label className="md:hidden text-xs">Desc.</Label>
+                  <Input type="number" min="0" step="0.01" {...register(`itens.${i}.desconto`)} aria-label={`Desconto item ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-1 space-y-1">
+                  <Label className="md:hidden text-xs">IVA %</Label>
+                  <Select
+                    defaultValue="0.16"
+                    onValueChange={(v) => setValue(`itens.${i}.taxaIva`, parseFloat(v))}
+                  >
+                    <SelectTrigger className="h-9" aria-label={`Taxa IVA item ${i + 1}`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="0.16">16%</SelectItem>
+                      <SelectItem value="0">0%</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="col-span-3 md:col-span-1 flex items-center justify-end pt-1">
+                  <span className="text-sm tabular-nums font-medium">{fmtMZN.format(total)}</span>
+                </div>
+                <div className="col-span-1 flex items-start pt-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    disabled={fields.length === 1}
+                    onClick={() => remove(i)}
+                    aria-label="Remover item"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+
+          {errors.itens?.root && (
+            <p className="text-sm text-destructive flex items-center gap-1">
+              <AlertCircle className="h-4 w-4" />
+              {errors.itens.root.message}
+            </p>
+          )}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => append({ descricao: '', quantidade: 1, unidadeMedida: 'un', precoUnitario: 0, desconto: 0, taxaIva: 0.16 })}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Adicionar item
+          </Button>
+
+          <div className="border-t pt-4 space-y-1 text-sm max-w-xs ml-auto">
+            <div className="flex justify-between text-muted-foreground">
+              <span>Subtotal</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.subtotal)}</span>
+            </div>
+            <div className="flex justify-between text-muted-foreground">
+              <span>IVA</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.iva)}</span>
+            </div>
+            <div className="flex justify-between font-semibold text-base">
+              <span>Total</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.total)}</span>
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection title="Observações" description="Notas adicionais para o fornecedor">
+          <Textarea
+            {...register('observacoes')}
+            placeholder="Observações adicionais (opcional)…"
+            rows={3}
+          />
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/compras/pedidos/novo/page.tsx
+++ b/apps/erp/src/app/(dashboard)/compras/pedidos/novo/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * Novo Pedido de Compra — Server Component shell.
+ */
+
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { PageHeader } from '@/components/patterns';
+import { NovoPedidoForm } from './_components/novo-pedido-form';
+
+export default async function NovoPedidoPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+
+  return (
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Novo Pedido de Compra"
+        description="Emissão de pedido de compra a fornecedor"
+        breadcrumbs={[
+          { label: 'Compras', href: '/compras' },
+          { label: 'Pedidos', href: '/compras/pedidos' },
+          { label: 'Novo Pedido' },
+        ]}
+      />
+      <NovoPedidoForm />
+    </div>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/faturacao/cotacoes/nova/_components/nova-cotacao-form.tsx
+++ b/apps/erp/src/app/(dashboard)/faturacao/cotacoes/nova/_components/nova-cotacao-form.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm, useFieldArray, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Plus, Trash2, Save, X, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { criarCotacaoComercial } from '@/server/actions/faturacao.actions';
+
+// ponytail: schema do formulário (client-safe); o servidor revalida com CriarCotacaoComercialSchema.
+const LinhaFormSchema = z.object({
+  descricao: z.string().min(1, 'Descrição obrigatória'),
+  quantidade: z.coerce.number().positive('Quantidade positiva'),
+  precoUnitario: z.coerce.number().nonnegative('Preço não negativo'),
+  desconto: z.coerce.number().nonnegative().default(0),
+  taxaIva: z.coerce.number().default(0.16),
+});
+
+const FormSchema = z
+  .object({
+    serieDocumentoId: z.string().min(1, 'Série obrigatória'),
+    clienteId: z.string().min(1, 'Cliente obrigatório'),
+    dataEmissao: z.string().min(1, 'Data obrigatória'),
+    dataValidade: z.string().min(1, 'Data obrigatória'),
+    condicoesComerciais: z.string().optional(),
+    observacoes: z.string().optional(),
+    linhas: z.array(LinhaFormSchema).min(1, 'Mínimo 1 linha'),
+  })
+  .refine((d) => d.dataValidade > d.dataEmissao, {
+    message: 'Data de validade deve ser posterior à data de emissão',
+    path: ['dataValidade'],
+  });
+
+type FormValues = z.infer<typeof FormSchema>;
+
+interface Props {
+  series: Array<{ id: string; codigo: string; nome: string }>;
+}
+
+const today = new Date().toISOString().split('T')[0];
+
+export function NovaCotacaoForm({ series }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    setValue,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      serieDocumentoId: series[0]?.id ?? '',
+      clienteId: '',
+      dataEmissao: today,
+      dataValidade: '',
+      condicoesComerciais: '',
+      observacoes: '',
+      linhas: [{ descricao: '', quantidade: 1, precoUnitario: 0, desconto: 0, taxaIva: 0.16 }],
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({ control, name: 'linhas' });
+  const linhas = useWatch({ control, name: 'linhas' }) ?? [];
+
+  const totais = linhas.reduce(
+    (acc, l) => {
+      const q = Number(l.quantidade) || 0;
+      const p = Number(l.precoUnitario) || 0;
+      const d = Number(l.desconto) || 0;
+      const taxa = Number(l.taxaIva) || 0.16;
+      const base = q * p - d;
+      const iva = base * taxa;
+      return { subtotal: acc.subtotal + base, iva: acc.iva + iva, total: acc.total + base + iva };
+    },
+    { subtotal: 0, iva: 0, total: 0 },
+  );
+
+  const fmtMZN = new Intl.NumberFormat('pt-MZ', { style: 'currency', currency: 'MZN' });
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const result = await criarCotacaoComercial({
+        serieDocumentoId: values.serieDocumentoId,
+        clienteId: values.clienteId,
+        moeda: 'MZN',
+        dataEmissao: values.dataEmissao,
+        dataValidade: values.dataValidade,
+        condicoesComerciais: values.condicoesComerciais || undefined,
+        observacoes: values.observacoes || undefined,
+        linhas: values.linhas.map((l, i) => ({
+          descricao: l.descricao,
+          quantidade: Number(l.quantidade),
+          precoUnitario: Number(l.precoUnitario),
+          desconto: Number(l.desconto) || 0,
+          taxaIva: Number(l.taxaIva) || 0.16,
+          ordemLinha: i,
+        })),
+      } as any);
+
+      if (result?.ok) {
+        toast.success('Cotação criada com sucesso.');
+        router.push('/faturacao/cotacoes');
+      } else {
+        toast.error((result as any)?.error?.message ?? 'Erro ao criar cotação.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/faturacao/cotacoes')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A criar…' : 'Criar Cotação'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Série e Cliente" description="Identifique a série e o destinatário da cotação">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="serie-cotacao">Série de Documento *</Label>
+              <Select
+                defaultValue={series[0]?.id ?? ''}
+                onValueChange={(v) => setValue('serieDocumentoId', v)}
+              >
+                <SelectTrigger id="serie-cotacao" aria-label="Série de Documento">
+                  <SelectValue placeholder="Seleccione a série" />
+                </SelectTrigger>
+                <SelectContent>
+                  {series.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>{s.codigo} — {s.nome}</SelectItem>
+                  ))}
+                  {series.length === 0 && (
+                    <SelectItem value="" disabled>Sem séries configuradas</SelectItem>
+                  )}
+                </SelectContent>
+              </Select>
+              {errors.serieDocumentoId && (
+                <p className="text-sm text-destructive">{errors.serieDocumentoId.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="cliente-id">ID do Cliente *</Label>
+              <Input id="cliente-id" {...register('clienteId')} placeholder="ID do cliente (CUID)" />
+              <p className="text-xs text-muted-foreground">Pesquisa de clientes disponível após integração comercial.</p>
+              {errors.clienteId && (
+                <p className="text-sm text-destructive">{errors.clienteId.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="data-emissao">Data de Emissão *</Label>
+              <Input id="data-emissao" type="date" {...register('dataEmissao')} />
+              {errors.dataEmissao && (
+                <p className="text-sm text-destructive">{errors.dataEmissao.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="data-validade">Data de Validade *</Label>
+              <Input id="data-validade" type="date" {...register('dataValidade')} />
+              {errors.dataValidade && (
+                <p className="text-sm text-destructive">{errors.dataValidade.message}</p>
+              )}
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection title="Linhas da Cotação" description="Produtos ou serviços a cotar">
+          <div className="hidden md:grid grid-cols-12 gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
+            <span className="col-span-4">Descrição</span>
+            <span className="col-span-2">Qtd</span>
+            <span className="col-span-2">Preço Unit.</span>
+            <span className="col-span-1">Desc.</span>
+            <span className="col-span-1">IVA %</span>
+            <span className="col-span-1 text-right">Total</span>
+            <span className="col-span-1"></span>
+          </div>
+
+          {fields.map((field, i) => {
+            const q = Number(linhas[i]?.quantidade) || 0;
+            const p = Number(linhas[i]?.precoUnitario) || 0;
+            const d = Number(linhas[i]?.desconto) || 0;
+            const taxa = Number(linhas[i]?.taxaIva) || 0.16;
+            const base = q * p - d;
+            const total = base + base * taxa;
+
+            return (
+              <div key={field.id} className="grid grid-cols-12 gap-2 items-start">
+                <div className="col-span-12 md:col-span-4 space-y-1">
+                  <Label className="md:hidden text-xs" htmlFor={`linha-descricao-${i}`}>Descrição *</Label>
+                  <Input id={`linha-descricao-${i}`} {...register(`linhas.${i}.descricao`)} placeholder="Descrição do produto/serviço" aria-label={`Descrição da linha ${i + 1}`} />
+                  {errors.linhas?.[i]?.descricao && (
+                    <p className="text-xs text-destructive">{errors.linhas[i]?.descricao?.message}</p>
+                  )}
+                </div>
+                <div className="col-span-4 md:col-span-2 space-y-1">
+                  <Label className="md:hidden text-xs">Qtd</Label>
+                  <Input type="number" min="0.01" step="0.01" {...register(`linhas.${i}.quantidade`)} aria-label={`Quantidade linha ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-2 space-y-1">
+                  <Label className="md:hidden text-xs">Preço</Label>
+                  <Input type="number" min="0" step="0.01" {...register(`linhas.${i}.precoUnitario`)} aria-label={`Preço unitário linha ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-1 space-y-1">
+                  <Label className="md:hidden text-xs">Desc.</Label>
+                  <Input type="number" min="0" step="0.01" {...register(`linhas.${i}.desconto`)} aria-label={`Desconto linha ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-1 space-y-1">
+                  <Label className="md:hidden text-xs">IVA %</Label>
+                  <Select
+                    defaultValue="0.16"
+                    onValueChange={(v) => setValue(`linhas.${i}.taxaIva`, parseFloat(v))}
+                  >
+                    <SelectTrigger className="h-9" aria-label={`Taxa IVA linha ${i + 1}`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="0.16">16%</SelectItem>
+                      <SelectItem value="0">0%</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="col-span-3 md:col-span-1 flex items-center justify-end pt-1">
+                  <span className="text-sm tabular-nums font-medium">{fmtMZN.format(total)}</span>
+                </div>
+                <div className="col-span-1 flex items-start pt-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    disabled={fields.length === 1}
+                    onClick={() => remove(i)}
+                    aria-label="Remover linha"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+
+          {errors.linhas?.root && (
+            <p className="text-sm text-destructive flex items-center gap-1">
+              <AlertCircle className="h-4 w-4" />
+              {errors.linhas.root.message}
+            </p>
+          )}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => append({ descricao: '', quantidade: 1, precoUnitario: 0, desconto: 0, taxaIva: 0.16 })}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Adicionar linha
+          </Button>
+
+          <div className="border-t pt-4 space-y-1 text-sm max-w-xs ml-auto">
+            <div className="flex justify-between text-muted-foreground">
+              <span>Subtotal</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.subtotal)}</span>
+            </div>
+            <div className="flex justify-between text-muted-foreground">
+              <span>IVA</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.iva)}</span>
+            </div>
+            <div className="flex justify-between font-semibold text-base">
+              <span>Total</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.total)}</span>
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection title="Condições e Observações" description="Condições comerciais e notas para o cliente">
+          <div className="space-y-2">
+            <Label htmlFor="condicoes">Condições Comerciais</Label>
+            <Textarea
+              id="condicoes"
+              {...register('condicoesComerciais')}
+              placeholder="Prazo de entrega, forma de pagamento, garantias… (opcional)"
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="observacoes">Observações</Label>
+            <Textarea
+              id="observacoes"
+              {...register('observacoes')}
+              placeholder="Observações adicionais (opcional)…"
+              rows={3}
+            />
+          </div>
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/faturacao/cotacoes/nova/page.tsx
+++ b/apps/erp/src/app/(dashboard)/faturacao/cotacoes/nova/page.tsx
@@ -1,0 +1,47 @@
+/**
+ * Nova Cotação Comercial — Server Component shell.
+ * Carrega as séries de documento para o formulário; o cliente é indicado por ID
+ * (mesmo padrão de `faturacao/nova`, até haver pesquisa comercial integrada).
+ */
+
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { runWithTenantContext } from '@/server/db/tenant-extension';
+import * as faturacaoService from '@/server/services/financas/faturacao.service';
+import { PageHeader } from '@/components/patterns';
+import { NovaCotacaoForm } from './_components/nova-cotacao-form';
+
+export default async function NovaCotacaoPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+  const { tenantId, id: userId } = session.user;
+
+  let series: Array<{ id: string; codigo: string; nome: string }> = [];
+  try {
+    const rawSeries = await runWithTenantContext({ tenantId, userId }, () =>
+      faturacaoService.listarSeries({ tenantId, userId }),
+    );
+    series = rawSeries.map((s: any) => ({
+      id: s.id,
+      codigo: s.codigo,
+      nome: s.nome ?? s.codigo,
+    }));
+  } catch {
+    // O formulário mostra lista de séries vazia.
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Nova Cotação"
+        description="Proposta ou orçamento para o cliente"
+        breadcrumbs={[
+          { label: 'Faturação', href: '/faturacao' },
+          { label: 'Cotações', href: '/faturacao/cotacoes' },
+          { label: 'Nova Cotação' },
+        ]}
+      />
+      <NovaCotacaoForm series={series} />
+    </div>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/faturacao/nota-credito/nova/_components/nova-nota-credito-form.tsx
+++ b/apps/erp/src/app/(dashboard)/faturacao/nota-credito/nova/_components/nova-nota-credito-form.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm, useFieldArray, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Plus, Trash2, Save, X, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { emitirNotaCredito } from '@/server/actions/faturacao.actions';
+
+// Mesmo bloco de linhas da fatura (LinhaDocumentoSchema)
+const LinhaFormSchema = z.object({
+  descricao: z.string().min(1, 'Descrição obrigatória'),
+  quantidade: z.coerce.number().positive('Quantidade positiva'),
+  precoUnitario: z.coerce.number().nonnegative('Preço não negativo'),
+  desconto: z.coerce.number().nonnegative().default(0),
+  taxaIva: z.coerce.number().default(0.16),
+});
+
+const FormSchema = z.object({
+  serieDocumentoId: z.string().min(1, 'Série obrigatória'),
+  faturaOriginalId: z.string().min(1, 'Factura original obrigatória'),
+  motivo: z.string().min(1, 'Motivo obrigatório'),
+  dataEmissao: z.string().min(1, 'Data obrigatória'),
+  observacoes: z.string().optional(),
+  linhas: z.array(LinhaFormSchema).min(1, 'Mínimo 1 linha'),
+});
+
+type FormValues = z.infer<typeof FormSchema>;
+
+interface Props {
+  series: Array<{ id: string; codigo: string; nome: string }>;
+}
+
+const today = new Date().toISOString().split('T')[0];
+
+export function NovaNotaCreditoForm({ series }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    setValue,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      serieDocumentoId: series[0]?.id ?? '',
+      faturaOriginalId: '',
+      motivo: '',
+      dataEmissao: today,
+      observacoes: '',
+      linhas: [{ descricao: '', quantidade: 1, precoUnitario: 0, desconto: 0, taxaIva: 0.16 }],
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({ control, name: 'linhas' });
+  const linhas = useWatch({ control, name: 'linhas' }) ?? [];
+
+  const totais = linhas.reduce(
+    (acc, l) => {
+      const q = Number(l.quantidade) || 0;
+      const p = Number(l.precoUnitario) || 0;
+      const d = Number(l.desconto) || 0;
+      const taxa = Number(l.taxaIva) || 0.16;
+      const base = q * p - d;
+      const iva = base * taxa;
+      return { subtotal: acc.subtotal + base, iva: acc.iva + iva, total: acc.total + base + iva };
+    },
+    { subtotal: 0, iva: 0, total: 0 }
+  );
+
+  const fmtMZN = new Intl.NumberFormat('pt-MZ', { style: 'currency', currency: 'MZN' });
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const result = await emitirNotaCredito({
+        serieDocumentoId: values.serieDocumentoId,
+        faturaOriginalId: values.faturaOriginalId,
+        motivo: values.motivo,
+        moeda: 'MZN',
+        dataEmissao: values.dataEmissao,
+        observacoes: values.observacoes || undefined,
+        linhas: values.linhas.map((l, i) => ({
+          descricao: l.descricao,
+          quantidade: Number(l.quantidade),
+          precoUnitario: Number(l.precoUnitario),
+          desconto: Number(l.desconto) || 0,
+          taxaIva: Number(l.taxaIva) || 0.16,
+          ordemLinha: i,
+        })),
+      } as any);
+
+      if (result?.ok) {
+        toast.success('Nota de crédito emitida com sucesso.');
+        router.push('/faturacao/nota-credito');
+      } else {
+        toast.error((result as any)?.error?.message ?? 'Erro ao emitir nota de crédito.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/faturacao/nota-credito')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A emitir…' : 'Emitir Nota de Crédito'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Série e Factura Original" description="Identifique a série e a factura a creditar">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="serie-nc">Série de Documento *</Label>
+              <Select
+                defaultValue={series[0]?.id ?? ''}
+                onValueChange={(v) => setValue('serieDocumentoId', v)}
+              >
+                <SelectTrigger id="serie-nc" aria-label="Série de Documento">
+                  <SelectValue placeholder="Seleccione a série" />
+                </SelectTrigger>
+                <SelectContent>
+                  {series.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>{s.codigo} — {s.nome}</SelectItem>
+                  ))}
+                  {series.length === 0 && (
+                    <SelectItem value="" disabled>Sem séries configuradas</SelectItem>
+                  )}
+                </SelectContent>
+              </Select>
+              {errors.serieDocumentoId && (
+                <p className="text-sm text-destructive">{errors.serieDocumentoId.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="fatura-original-id">ID da Factura a Creditar *</Label>
+              <Input id="fatura-original-id" {...register('faturaOriginalId')} placeholder="ID da factura (CUID)" />
+              <p className="text-xs text-muted-foreground">Pesquisa de facturas disponível após integração comercial.</p>
+              {errors.faturaOriginalId && (
+                <p className="text-sm text-destructive">{errors.faturaOriginalId.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="data-emissao">Data de Emissão *</Label>
+              <Input id="data-emissao" type="date" {...register('dataEmissao')} />
+              {errors.dataEmissao && (
+                <p className="text-sm text-destructive">{errors.dataEmissao.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="motivo">Motivo *</Label>
+              <Input id="motivo" {...register('motivo')} placeholder="Motivo do crédito" />
+              {errors.motivo && (
+                <p className="text-sm text-destructive">{errors.motivo.message}</p>
+              )}
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection title="Linhas da Nota de Crédito" description="Itens a creditar">
+          <div className="hidden md:grid grid-cols-12 gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
+            <span className="col-span-4">Descrição</span>
+            <span className="col-span-2">Qtd</span>
+            <span className="col-span-2">Preço Unit.</span>
+            <span className="col-span-1">Desc.</span>
+            <span className="col-span-1">IVA %</span>
+            <span className="col-span-1 text-right">Total</span>
+            <span className="col-span-1"></span>
+          </div>
+
+          {fields.map((field, i) => {
+            const q = Number(linhas[i]?.quantidade) || 0;
+            const p = Number(linhas[i]?.precoUnitario) || 0;
+            const d = Number(linhas[i]?.desconto) || 0;
+            const taxa = Number(linhas[i]?.taxaIva) || 0.16;
+            const base = q * p - d;
+            const total = base + base * taxa;
+
+            return (
+              <div key={field.id} className="grid grid-cols-12 gap-2 items-start">
+                <div className="col-span-12 md:col-span-4 space-y-1">
+                  <Label className="md:hidden text-xs" htmlFor={`linha-descricao-${i}`}>Descrição *</Label>
+                  <Input id={`linha-descricao-${i}`} {...register(`linhas.${i}.descricao`)} placeholder="Descrição do item" aria-label={`Descrição da linha ${i + 1}`} />
+                  {errors.linhas?.[i]?.descricao && (
+                    <p className="text-xs text-destructive">{errors.linhas[i]?.descricao?.message}</p>
+                  )}
+                </div>
+                <div className="col-span-4 md:col-span-2 space-y-1">
+                  <Label className="md:hidden text-xs">Qtd</Label>
+                  <Input type="number" min="0.01" step="0.01" {...register(`linhas.${i}.quantidade`)} aria-label={`Quantidade linha ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-2 space-y-1">
+                  <Label className="md:hidden text-xs">Preço</Label>
+                  <Input type="number" min="0" step="0.01" {...register(`linhas.${i}.precoUnitario`)} aria-label={`Preço unitário linha ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-1 space-y-1">
+                  <Label className="md:hidden text-xs">Desc.</Label>
+                  <Input type="number" min="0" step="0.01" {...register(`linhas.${i}.desconto`)} aria-label={`Desconto linha ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-1 space-y-1">
+                  <Label className="md:hidden text-xs">IVA %</Label>
+                  <Select
+                    defaultValue="0.16"
+                    onValueChange={(v) => setValue(`linhas.${i}.taxaIva`, parseFloat(v))}
+                  >
+                    <SelectTrigger className="h-9" aria-label={`Taxa IVA linha ${i + 1}`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="0.16">16%</SelectItem>
+                      <SelectItem value="0">0%</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="col-span-3 md:col-span-1 flex items-center justify-end pt-1">
+                  <span className="text-sm tabular-nums font-medium">{fmtMZN.format(total)}</span>
+                </div>
+                <div className="col-span-1 flex items-start pt-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    disabled={fields.length === 1}
+                    onClick={() => remove(i)}
+                    aria-label="Remover linha"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+
+          {errors.linhas?.root && (
+            <p className="text-sm text-destructive flex items-center gap-1">
+              <AlertCircle className="h-4 w-4" />
+              {errors.linhas.root.message}
+            </p>
+          )}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => append({ descricao: '', quantidade: 1, precoUnitario: 0, desconto: 0, taxaIva: 0.16 })}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Adicionar linha
+          </Button>
+
+          <div className="border-t pt-4 space-y-1 text-sm max-w-xs ml-auto">
+            <div className="flex justify-between text-muted-foreground">
+              <span>Subtotal</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.subtotal)}</span>
+            </div>
+            <div className="flex justify-between text-muted-foreground">
+              <span>IVA</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.iva)}</span>
+            </div>
+            <div className="flex justify-between font-semibold text-base">
+              <span>Total</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.total)}</span>
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection title="Observações" description="Notas adicionais">
+          <Textarea
+            {...register('observacoes')}
+            placeholder="Observações adicionais (opcional)…"
+            rows={3}
+          />
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/faturacao/nota-credito/nova/page.tsx
+++ b/apps/erp/src/app/(dashboard)/faturacao/nota-credito/nova/page.tsx
@@ -1,0 +1,48 @@
+/**
+ * Nova Nota de Crédito — Server Component shell.
+ * Carrega as séries de documento para o formulário CC.
+ */
+
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { runWithTenantContext } from '@/server/db/tenant-extension';
+import * as faturacaoService from '@/server/services/financas/faturacao.service';
+import { PageHeader } from '@/components/patterns';
+import { NovaNotaCreditoForm } from './_components/nova-nota-credito-form';
+
+export default async function NovaNotaCreditoPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+  const { tenantId, id: userId } = session.user;
+
+  let series: Array<{ id: string; codigo: string; nome: string }> = [];
+  try {
+    const rawSeries = await runWithTenantContext({ tenantId, userId }, () =>
+      faturacaoService.listarSeries({ tenantId, userId })
+    );
+    series = rawSeries
+      .filter((s: any) => s.tipo === 'NOTA_CREDITO')
+      .map((s: any) => ({
+        id: s.id,
+        codigo: s.prefixo,
+        nome: `${s.prefixo} ${s.ano}`,
+      }));
+  } catch {
+    // Form will show empty series list
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Nova Nota de Crédito"
+        description="Emissão de nota de crédito sobre factura"
+        breadcrumbs={[
+          { label: 'Faturação', href: '/faturacao' },
+          { label: 'Notas de Crédito', href: '/faturacao/nota-credito' },
+          { label: 'Nova Nota de Crédito' },
+        ]}
+      />
+      <NovaNotaCreditoForm series={series} />
+    </div>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/faturacao/proforma/nova/_components/nova-proforma-form.tsx
+++ b/apps/erp/src/app/(dashboard)/faturacao/proforma/nova/_components/nova-proforma-form.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm, useFieldArray, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Plus, Trash2, Save, X, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { criarProforma } from '@/server/actions/faturacao.actions';
+
+// ponytail: schema do formulário (client-safe); o servidor revalida com CriarProformaSchema.
+const LinhaFormSchema = z.object({
+  descricao: z.string().min(1, 'Descrição obrigatória'),
+  quantidade: z.coerce.number().positive('Quantidade positiva'),
+  precoUnitario: z.coerce.number().nonnegative('Preço não negativo'),
+  desconto: z.coerce.number().nonnegative().default(0),
+  taxaIva: z.coerce.number().default(0.16),
+});
+
+const FormSchema = z
+  .object({
+    serieDocumentoId: z.string().min(1, 'Série obrigatória'),
+    clienteId: z.string().min(1, 'Cliente obrigatório'),
+    dataEmissao: z.string().min(1, 'Data obrigatória'),
+    dataValidade: z.string().min(1, 'Data obrigatória'),
+    observacoes: z.string().optional(),
+    linhas: z.array(LinhaFormSchema).min(1, 'Mínimo 1 linha'),
+  })
+  .refine((d) => d.dataValidade > d.dataEmissao, {
+    message: 'Data de validade deve ser posterior à data de emissão',
+    path: ['dataValidade'],
+  });
+
+type FormValues = z.infer<typeof FormSchema>;
+
+interface Props {
+  series: Array<{ id: string; codigo: string; nome: string }>;
+}
+
+const today = new Date().toISOString().split('T')[0];
+
+export function NovaProformaForm({ series }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    setValue,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      serieDocumentoId: series[0]?.id ?? '',
+      clienteId: '',
+      dataEmissao: today,
+      dataValidade: '',
+      observacoes: '',
+      linhas: [{ descricao: '', quantidade: 1, precoUnitario: 0, desconto: 0, taxaIva: 0.16 }],
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({ control, name: 'linhas' });
+  const linhas = useWatch({ control, name: 'linhas' }) ?? [];
+
+  const totais = linhas.reduce(
+    (acc, l) => {
+      const q = Number(l.quantidade) || 0;
+      const p = Number(l.precoUnitario) || 0;
+      const d = Number(l.desconto) || 0;
+      const taxa = Number(l.taxaIva) || 0.16;
+      const base = q * p - d;
+      const iva = base * taxa;
+      return { subtotal: acc.subtotal + base, iva: acc.iva + iva, total: acc.total + base + iva };
+    },
+    { subtotal: 0, iva: 0, total: 0 },
+  );
+
+  const fmtMZN = new Intl.NumberFormat('pt-MZ', { style: 'currency', currency: 'MZN' });
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const result = await criarProforma({
+        serieDocumentoId: values.serieDocumentoId,
+        clienteId: values.clienteId,
+        moeda: 'MZN',
+        dataEmissao: values.dataEmissao,
+        dataValidade: values.dataValidade,
+        observacoes: values.observacoes || undefined,
+        linhas: values.linhas.map((l, i) => ({
+          descricao: l.descricao,
+          quantidade: Number(l.quantidade),
+          precoUnitario: Number(l.precoUnitario),
+          desconto: Number(l.desconto) || 0,
+          taxaIva: Number(l.taxaIva) || 0.16,
+          ordemLinha: i,
+        })),
+      } as any);
+
+      if (result?.ok) {
+        toast.success('Proforma criada com sucesso.');
+        router.push('/faturacao/proforma');
+      } else {
+        toast.error((result as any)?.error?.message ?? 'Erro ao criar proforma.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/faturacao/proforma')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A criar…' : 'Criar Proforma'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Série e Cliente" description="Identifique a série e o destinatário da proforma">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="serie-proforma">Série de Documento *</Label>
+              <Select
+                defaultValue={series[0]?.id ?? ''}
+                onValueChange={(v) => setValue('serieDocumentoId', v)}
+              >
+                <SelectTrigger id="serie-proforma" aria-label="Série de Documento">
+                  <SelectValue placeholder="Seleccione a série" />
+                </SelectTrigger>
+                <SelectContent>
+                  {series.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>{s.codigo} — {s.nome}</SelectItem>
+                  ))}
+                  {series.length === 0 && (
+                    <SelectItem value="" disabled>Sem séries configuradas</SelectItem>
+                  )}
+                </SelectContent>
+              </Select>
+              {errors.serieDocumentoId && (
+                <p className="text-sm text-destructive">{errors.serieDocumentoId.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="cliente-id">ID do Cliente *</Label>
+              <Input id="cliente-id" {...register('clienteId')} placeholder="ID do cliente (CUID)" />
+              <p className="text-xs text-muted-foreground">Pesquisa de clientes disponível após integração comercial.</p>
+              {errors.clienteId && (
+                <p className="text-sm text-destructive">{errors.clienteId.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="data-emissao">Data de Emissão *</Label>
+              <Input id="data-emissao" type="date" {...register('dataEmissao')} />
+              {errors.dataEmissao && (
+                <p className="text-sm text-destructive">{errors.dataEmissao.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="data-validade">Data de Validade *</Label>
+              <Input id="data-validade" type="date" {...register('dataValidade')} />
+              {errors.dataValidade && (
+                <p className="text-sm text-destructive">{errors.dataValidade.message}</p>
+              )}
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection title="Linhas da Proforma" description="Produtos ou serviços a incluir">
+          <div className="hidden md:grid grid-cols-12 gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
+            <span className="col-span-4">Descrição</span>
+            <span className="col-span-2">Qtd</span>
+            <span className="col-span-2">Preço Unit.</span>
+            <span className="col-span-1">Desc.</span>
+            <span className="col-span-1">IVA %</span>
+            <span className="col-span-1 text-right">Total</span>
+            <span className="col-span-1"></span>
+          </div>
+
+          {fields.map((field, i) => {
+            const q = Number(linhas[i]?.quantidade) || 0;
+            const p = Number(linhas[i]?.precoUnitario) || 0;
+            const d = Number(linhas[i]?.desconto) || 0;
+            const taxa = Number(linhas[i]?.taxaIva) || 0.16;
+            const base = q * p - d;
+            const total = base + base * taxa;
+
+            return (
+              <div key={field.id} className="grid grid-cols-12 gap-2 items-start">
+                <div className="col-span-12 md:col-span-4 space-y-1">
+                  <Label className="md:hidden text-xs" htmlFor={`linha-descricao-${i}`}>Descrição *</Label>
+                  <Input id={`linha-descricao-${i}`} {...register(`linhas.${i}.descricao`)} placeholder="Descrição do produto/serviço" aria-label={`Descrição da linha ${i + 1}`} />
+                  {errors.linhas?.[i]?.descricao && (
+                    <p className="text-xs text-destructive">{errors.linhas[i]?.descricao?.message}</p>
+                  )}
+                </div>
+                <div className="col-span-4 md:col-span-2 space-y-1">
+                  <Label className="md:hidden text-xs">Qtd</Label>
+                  <Input type="number" min="0.01" step="0.01" {...register(`linhas.${i}.quantidade`)} aria-label={`Quantidade linha ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-2 space-y-1">
+                  <Label className="md:hidden text-xs">Preço</Label>
+                  <Input type="number" min="0" step="0.01" {...register(`linhas.${i}.precoUnitario`)} aria-label={`Preço unitário linha ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-1 space-y-1">
+                  <Label className="md:hidden text-xs">Desc.</Label>
+                  <Input type="number" min="0" step="0.01" {...register(`linhas.${i}.desconto`)} aria-label={`Desconto linha ${i + 1}`} />
+                </div>
+                <div className="col-span-4 md:col-span-1 space-y-1">
+                  <Label className="md:hidden text-xs">IVA %</Label>
+                  <Select
+                    defaultValue="0.16"
+                    onValueChange={(v) => setValue(`linhas.${i}.taxaIva`, parseFloat(v))}
+                  >
+                    <SelectTrigger className="h-9" aria-label={`Taxa IVA linha ${i + 1}`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="0.16">16%</SelectItem>
+                      <SelectItem value="0">0%</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="col-span-3 md:col-span-1 flex items-center justify-end pt-1">
+                  <span className="text-sm tabular-nums font-medium">{fmtMZN.format(total)}</span>
+                </div>
+                <div className="col-span-1 flex items-start pt-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    disabled={fields.length === 1}
+                    onClick={() => remove(i)}
+                    aria-label="Remover linha"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+
+          {errors.linhas?.root && (
+            <p className="text-sm text-destructive flex items-center gap-1">
+              <AlertCircle className="h-4 w-4" />
+              {errors.linhas.root.message}
+            </p>
+          )}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => append({ descricao: '', quantidade: 1, precoUnitario: 0, desconto: 0, taxaIva: 0.16 })}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Adicionar linha
+          </Button>
+
+          <div className="border-t pt-4 space-y-1 text-sm max-w-xs ml-auto">
+            <div className="flex justify-between text-muted-foreground">
+              <span>Subtotal</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.subtotal)}</span>
+            </div>
+            <div className="flex justify-between text-muted-foreground">
+              <span>IVA</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.iva)}</span>
+            </div>
+            <div className="flex justify-between font-semibold text-base">
+              <span>Total</span>
+              <span className="tabular-nums">{fmtMZN.format(totais.total)}</span>
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection title="Observações" description="Notas adicionais para o cliente">
+          <Textarea
+            {...register('observacoes')}
+            placeholder="Observações adicionais (opcional)…"
+            rows={3}
+          />
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/faturacao/proforma/nova/page.tsx
+++ b/apps/erp/src/app/(dashboard)/faturacao/proforma/nova/page.tsx
@@ -1,278 +1,47 @@
+/**
+ * Nova Fatura Proforma — Server Component shell.
+ * Carrega as séries de documento; o cliente é indicado por ID (mesmo padrão de
+ * `faturacao/nova`, até haver pesquisa comercial integrada).
+ */
 
-'use client';
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { runWithTenantContext } from '@/server/db/tenant-extension';
+import * as faturacaoService from '@/server/services/financas/faturacao.service';
+import { PageHeader } from '@/components/patterns';
+import { NovaProformaForm } from './_components/nova-proforma-form';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Textarea } from '@/components/ui/textarea';
-import { Plus, Trash2, Save, X } from 'lucide-react';
-import { toast } from 'sonner';
+export default async function NovaProformaPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+  const { tenantId, id: userId } = session.user;
 
-interface ItemProforma {
-  id: string;
-  descricao: string;
-  quantidade: number;
-  valorUnitario: number;
-  unidade: string;
-}
-
-export default function NovaProformaPage() {
-  const router = useRouter();
-  const [formData, setFormData] = useState({
-    cliente: '',
-    dataValidade: '',
-    observacoes: '',
-  });
-
-  const [itens, setItens] = useState<ItemProforma[]>([
-    { id: '1', descricao: '', quantidade: 1, valorUnitario: 0, unidade: 'un' }
-  ]);
-
-  const handleAddItem = () => {
-    const novoItem: ItemProforma = {
-      id: `item_${Date.now()}`,
-      descricao: '',
-      quantidade: 1,
-      valorUnitario: 0,
-      unidade: 'un'
-    };
-    setItens([...itens, novoItem]);
-  };
-
-  const handleRemoveItem = (id: string) => {
-    if (itens.length > 1) {
-      setItens(itens.filter(item => item.id !== id));
-    } else {
-      toast.error('Deve haver pelo menos um item');
-    }
-  };
-
-  const handleUpdateItem = (id: string, field: string, value: any) => {
-    setItens(itens.map(item =>
-      item.id === id ? { ...item, [field]: value } : item
-    ));
-  };
-
-  const calcularTotal = () => {
-    return itens.reduce((total, item) => total + (item.quantidade * item.valorUnitario), 0);
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!formData.cliente || !formData.dataValidade) {
-      toast.error('Preencha todos os campos obrigatórios');
-      return;
-    }
-
-    if (itens.some(item => !item.descricao || item.valorUnitario === 0)) {
-      toast.error('Preencha todos os itens com descrição e valor');
-      return;
-    }
-
-    toast.success('Proforma criada com sucesso');
-    setTimeout(() => {
-      router.push('/faturacao/proforma');
-    }, 1500);
-  };
-
-  const total = calcularTotal();
+  let series: Array<{ id: string; codigo: string; nome: string }> = [];
+  try {
+    const rawSeries = await runWithTenantContext({ tenantId, userId }, () =>
+      faturacaoService.listarSeries({ tenantId, userId }),
+    );
+    series = rawSeries.map((s: any) => ({
+      id: s.id,
+      codigo: s.codigo,
+      nome: s.nome ?? s.codigo,
+    }));
+  } catch {
+    // O formulário mostra lista de séries vazia.
+  }
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold">Nova Fatura Proforma</h1>
-          <p className="text-muted-foreground mt-2">Crie uma nova fatura proforma para o cliente</p>
-        </div>
-      </div>
-
-      <form onSubmit={handleSubmit} className="space-y-6">
-        {/* Informações Gerais */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Informações Gerais</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="cliente">Cliente *</Label>
-                <Select value={formData.cliente} onValueChange={(value) => setFormData(prev => ({ ...prev, cliente: value }))}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione um cliente" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="joao-silva">João Silva</SelectItem>
-                    <SelectItem value="empresa-abc">Empresa ABC Lda</SelectItem>
-                    <SelectItem value="maria-santos">Maria Santos</SelectItem>
-                    <SelectItem value="comercio-xyz">Comércio XYZ</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="dataValidade">Data de Validade *</Label>
-                <Input
-                  id="dataValidade"
-                  type="date"
-                  value={formData.dataValidade}
-                  onChange={(e) => setFormData(prev => ({ ...prev, dataValidade: e.target.value }))}
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="observacoes">Observações</Label>
-              <Textarea
-                id="observacoes"
-                value={formData.observacoes}
-                onChange={(e) => setFormData(prev => ({ ...prev, observacoes: e.target.value }))}
-                placeholder="Adicione observações sobre a proforma..."
-                rows={3}
-              />
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Itens da Proforma */}
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>Itens da Proforma</CardTitle>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={handleAddItem}
-              className="gap-2"
-            >
-              <Plus className="h-4 w-4" />
-              Adicionar Item
-            </Button>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {itens.map((item, index) => (
-              <div key={item.id} className="p-4 border rounded-lg space-y-3">
-                <div className="flex items-center justify-between">
-                  <p className="font-medium">Item {index + 1}</p>
-                  {itens.length > 1 && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleRemoveItem(item.id)}
-                    >
-                      <Trash2 className="h-4 w-4 text-red-600" />
-                    </Button>
-                  )}
-                </div>
-
-                <div className="space-y-2">
-                  <Label>Descrição *</Label>
-                  <Input
-                    value={item.descricao}
-                    onChange={(e) => handleUpdateItem(item.id, 'descricao', e.target.value)}
-                    placeholder="Descrição do item"
-                  />
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                  <div className="space-y-2">
-                    <Label>Quantidade *</Label>
-                    <Input
-                      type="number"
-                      min="1"
-                      value={item.quantidade}
-                      onChange={(e) => handleUpdateItem(item.id, 'quantidade', parseInt(e.target.value))}
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label>Unidade</Label>
-                    <Select value={item.unidade} onValueChange={(value) => handleUpdateItem(item.id, 'unidade', value)}>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="un">Unidade</SelectItem>
-                        <SelectItem value="kg">Quilograma</SelectItem>
-                        <SelectItem value="l">Litro</SelectItem>
-                        <SelectItem value="m">Metro</SelectItem>
-                        <SelectItem value="m2">Metro Quadrado</SelectItem>
-                        <SelectItem value="caixa">Caixa</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label>Valor Unitário (MT) *</Label>
-                    <Input
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      value={item.valorUnitario}
-                      onChange={(e) => handleUpdateItem(item.id, 'valorUnitario', parseFloat(e.target.value))}
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label>Subtotal</Label>
-                    <div className="flex items-center h-10 px-3 border rounded-md bg-muted">
-                      <span className="font-bold">MT {(item.quantidade * item.valorUnitario).toFixed(2)}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-
-        {/* Resumo */}
-        <Card className="bg-blue-50 dark:bg-blue-950 border-blue-200 dark:border-blue-800">
-          <CardContent className="pt-6">
-            <div className="space-y-2">
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground">Subtotal:</span>
-                <span className="font-medium">MT {total.toFixed(2)}</span>
-              </div>
-              <div className="flex justify-between items-center">
-                <span className="text-muted-foreground">Impostos (0%):</span>
-                <span className="font-medium">MT 0.00</span>
-              </div>
-              <div className="border-t pt-2 flex justify-between items-center">
-                <span className="font-bold">Total:</span>
-                <span className="text-2xl font-bold text-blue-600">MT {total.toFixed(2)}</span>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Botões */}
-        <div className="flex gap-4 justify-end">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => router.back()}
-            className="gap-2"
-          >
-            <X className="h-4 w-4" />
-            Cancelar
-          </Button>
-          <Button type="submit" className="gap-2">
-            <Save className="h-4 w-4" />
-            Criar Proforma
-          </Button>
-        </div>
-      </form>
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Nova Fatura Proforma"
+        description="Documento pró-forma para o cliente"
+        breadcrumbs={[
+          { label: 'Faturação', href: '/faturacao' },
+          { label: 'Proformas', href: '/faturacao/proforma' },
+          { label: 'Nova Proforma' },
+        ]}
+      />
+      <NovaProformaForm series={series} />
     </div>
   );
 }

--- a/apps/erp/src/app/(dashboard)/projetos/orcamento/novo/_components/novo-orcamento-projeto-form.tsx
+++ b/apps/erp/src/app/(dashboard)/projetos/orcamento/novo/_components/novo-orcamento-projeto-form.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm, useFieldArray, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Plus, Trash2, Save, X, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { criarOrcamentoProjetoAction } from '@/server/actions/projetos.actions';
+
+const TIPOS = [
+  { value: 'MAO_OBRA', label: 'Mão de Obra' },
+  { value: 'MATERIAL', label: 'Material' },
+  { value: 'EQUIPAMENTO', label: 'Equipamento' },
+  { value: 'SERVICO', label: 'Serviço' },
+  { value: 'OUTRO', label: 'Outro' },
+] as const;
+
+const CategoriaFormSchema = z.object({
+  nome: z.string().min(1, 'Nome obrigatório').max(100),
+  tipo: z.enum(['MAO_OBRA', 'MATERIAL', 'EQUIPAMENTO', 'SERVICO', 'OUTRO']),
+  valorPlanejado: z.coerce.number().nonnegative('Valor não pode ser negativo'),
+});
+
+const FormSchema = z.object({
+  projetoId: z.string().min(1, 'Projecto obrigatório'),
+  categorias: z.array(CategoriaFormSchema).min(1, 'Mínimo 1 categoria'),
+  observacoes: z.string().max(1000).optional(),
+});
+type FormValues = z.infer<typeof FormSchema>;
+
+const fmtMZN = new Intl.NumberFormat('pt-MZ', { style: 'currency', currency: 'MZN' });
+
+export function NovoOrcamentoProjetoForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const {
+    register,
+    control,
+    handleSubmit,
+    setValue,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      projetoId: '',
+      categorias: [{ nome: '', tipo: 'MAO_OBRA', valorPlanejado: 0 }],
+      observacoes: '',
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({ control, name: 'categorias' });
+  const categorias = useWatch({ control, name: 'categorias' }) ?? [];
+
+  const totalPlaneado = categorias.reduce((acc, c) => acc + (Number(c?.valorPlanejado) || 0), 0);
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const result = await criarOrcamentoProjetoAction({
+        projetoId: values.projetoId,
+        categorias: values.categorias.map((c) => ({
+          nome: c.nome,
+          tipo: c.tipo,
+          valorPlanejado: Number(c.valorPlanejado),
+          itens: [],
+        })),
+        observacoes: values.observacoes || undefined,
+      } as never);
+      if (result?.ok) {
+        toast.success('Orçamento criado com sucesso.');
+        router.push('/projetos/orcamento');
+      } else {
+        toast.error(result?.error?.message ?? 'Erro ao criar orçamento.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/projetos/orcamento')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A criar…' : 'Criar Orçamento'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Projecto" description="Projecto a orçamentar">
+          <div className="space-y-2">
+            <Label htmlFor="projetoId">ID do Projecto *</Label>
+            <Input id="projetoId" {...register('projetoId')} placeholder="ID do projecto (CUID)" />
+            {errors.projetoId && <p className="text-sm text-destructive">{errors.projetoId.message}</p>}
+          </div>
+        </FormSection>
+
+        <FormSection title="Categorias" description="Rubricas de custo e valores planeados">
+          <div className="hidden md:grid grid-cols-12 gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
+            <span className="col-span-5">Nome</span>
+            <span className="col-span-3">Tipo</span>
+            <span className="col-span-3">Valor Planeado</span>
+            <span className="col-span-1"></span>
+          </div>
+
+          {fields.map((field, i) => (
+            <div key={field.id} className="grid grid-cols-12 gap-2 items-start">
+              <div className="col-span-12 md:col-span-5 space-y-1">
+                <Label className="md:hidden text-xs" htmlFor={`categoria-nome-${i}`}>Nome *</Label>
+                <Input
+                  id={`categoria-nome-${i}`}
+                  {...register(`categorias.${i}.nome`)}
+                  placeholder="Ex.: Equipa de instalação"
+                  aria-label={`Nome da categoria ${i + 1}`}
+                />
+                {errors.categorias?.[i]?.nome && (
+                  <p className="text-xs text-destructive">{errors.categorias[i]?.nome?.message}</p>
+                )}
+              </div>
+              <div className="col-span-7 md:col-span-3 space-y-1">
+                <Label className="md:hidden text-xs">Tipo</Label>
+                <Select
+                  defaultValue="MAO_OBRA"
+                  onValueChange={(v) => setValue(`categorias.${i}.tipo`, v as FormValues['categorias'][number]['tipo'])}
+                >
+                  <SelectTrigger className="h-9" aria-label={`Tipo da categoria ${i + 1}`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TIPOS.map((t) => (
+                      <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="col-span-4 md:col-span-3 space-y-1">
+                <Label className="md:hidden text-xs">Valor</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  {...register(`categorias.${i}.valorPlanejado`)}
+                  aria-label={`Valor planeado da categoria ${i + 1}`}
+                />
+                {errors.categorias?.[i]?.valorPlanejado && (
+                  <p className="text-xs text-destructive">{errors.categorias[i]?.valorPlanejado?.message}</p>
+                )}
+              </div>
+              <div className="col-span-1 flex items-start pt-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  disabled={fields.length === 1}
+                  onClick={() => remove(i)}
+                  aria-label="Remover categoria"
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </div>
+            </div>
+          ))}
+
+          {errors.categorias?.root && (
+            <p className="text-sm text-destructive flex items-center gap-1">
+              <AlertCircle className="h-4 w-4" />
+              {errors.categorias.root.message}
+            </p>
+          )}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => append({ nome: '', tipo: 'MAO_OBRA', valorPlanejado: 0 })}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Adicionar categoria
+          </Button>
+
+          <div className="border-t pt-4 flex justify-between font-semibold text-base max-w-xs ml-auto">
+            <span>Total Planeado</span>
+            <span className="tabular-nums">{fmtMZN.format(totalPlaneado)}</span>
+          </div>
+        </FormSection>
+
+        <FormSection title="Observações" description="Notas adicionais (opcional)">
+          <Textarea {...register('observacoes')} placeholder="Observações adicionais…" rows={3} />
+          {errors.observacoes && <p className="text-sm text-destructive">{errors.observacoes.message}</p>}
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/projetos/orcamento/novo/page.tsx
+++ b/apps/erp/src/app/(dashboard)/projetos/orcamento/novo/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * Novo Orçamento de Projecto — Server Component shell.
+ */
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { PageHeader } from '@/components/patterns';
+import { NovoOrcamentoProjetoForm } from './_components/novo-orcamento-projeto-form';
+
+export default async function NovoOrcamentoProjetoPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+
+  return (
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Novo Orçamento"
+        description="Defina as categorias e valores planeados do projecto"
+        breadcrumbs={[
+          { label: 'Projectos', href: '/projetos' },
+          { label: 'Orçamento', href: '/projetos/orcamento' },
+          { label: 'Novo' },
+        ]}
+      />
+      <NovoOrcamentoProjetoForm />
+    </div>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/rh/ausencias/nova/_components/nova-ausencia-form.tsx
+++ b/apps/erp/src/app/(dashboard)/rh/ausencias/nova/_components/nova-ausencia-form.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Save, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { registarAusenciaAction } from '@/server/actions/rh.actions';
+
+const TIPOS = [
+  { value: 'FALTA', label: 'Falta' },
+  { value: 'ATESTADO_MEDICO', label: 'Atestado Médico' },
+  { value: 'LICENCA_MATERNIDADE', label: 'Licença de Maternidade' },
+  { value: 'LICENCA_PATERNIDADE', label: 'Licença de Paternidade' },
+  { value: 'LICENCA_SEM_VENCIMENTO', label: 'Licença sem Vencimento' },
+  { value: 'LICENCA_NOJO', label: 'Licença por Nojo' },
+  { value: 'LICENCA_CASAMENTO', label: 'Licença por Casamento' },
+  { value: 'OUTRO', label: 'Outro' },
+] as const;
+
+const FormSchema = z
+  .object({
+    colaboradorId: z.string().min(1, 'Colaborador obrigatório'),
+    tipo: z.enum([
+      'FALTA', 'ATESTADO_MEDICO', 'LICENCA_MATERNIDADE', 'LICENCA_PATERNIDADE',
+      'LICENCA_SEM_VENCIMENTO', 'LICENCA_NOJO', 'LICENCA_CASAMENTO', 'OUTRO',
+    ]),
+    dataInicio: z.string().min(1, 'Data de início obrigatória'),
+    dataFim: z.string().min(1, 'Data de fim obrigatória'),
+    justificada: z.boolean().default(false),
+    justificativa: z.string().max(1000).optional(),
+    observacoes: z.string().max(1000).optional(),
+  })
+  .refine((d) => d.dataFim >= d.dataInicio, {
+    message: 'Data de fim não pode ser anterior à data de início',
+    path: ['dataFim'],
+  });
+type FormValues = z.infer<typeof FormSchema>;
+
+export function NovaAusenciaForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      colaboradorId: '',
+      tipo: 'FALTA',
+      dataInicio: '',
+      dataFim: '',
+      justificada: false,
+      justificativa: '',
+      observacoes: '',
+    },
+  });
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const result = await registarAusenciaAction({
+        colaboradorId: values.colaboradorId,
+        tipo: values.tipo,
+        dataInicio: values.dataInicio,
+        dataFim: values.dataFim,
+        justificada: values.justificada,
+        justificativa: values.justificativa || undefined,
+        observacoes: values.observacoes || undefined,
+      } as never);
+      if (result?.ok) {
+        toast.success('Ausência registada com sucesso.');
+        router.push('/rh/ausencias');
+      } else {
+        toast.error(result?.error?.message ?? 'Erro ao registar ausência.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/rh/ausencias')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A registar…' : 'Registar Ausência'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Ausência" description="Colaborador, tipo e período da ausência">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="colaboradorId">ID do Colaborador *</Label>
+              <Input id="colaboradorId" {...register('colaboradorId')} placeholder="ID do colaborador (CUID)" />
+              {errors.colaboradorId && (
+                <p className="text-sm text-destructive">{errors.colaboradorId.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="tipo">Tipo *</Label>
+              <Select value={watch('tipo')} onValueChange={(v) => setValue('tipo', v as FormValues['tipo'])}>
+                <SelectTrigger id="tipo" aria-label="Tipo de ausência">
+                  <SelectValue placeholder="Seleccione o tipo" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TIPOS.map((t) => (
+                    <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {errors.tipo && <p className="text-sm text-destructive">{errors.tipo.message}</p>}
+            </div>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="dataInicio">Data de Início *</Label>
+              <Input id="dataInicio" type="date" {...register('dataInicio')} />
+              {errors.dataInicio && <p className="text-sm text-destructive">{errors.dataInicio.message}</p>}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="dataFim">Data de Fim *</Label>
+              <Input id="dataFim" type="date" {...register('dataFim')} />
+              {errors.dataFim && <p className="text-sm text-destructive">{errors.dataFim.message}</p>}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch
+              id="justificada"
+              checked={watch('justificada')}
+              onCheckedChange={(v) => setValue('justificada', v)}
+            />
+            <Label htmlFor="justificada">Justificada</Label>
+          </div>
+        </FormSection>
+
+        <FormSection title="Detalhes" description="Justificativa e observações (opcional)">
+          <div className="space-y-2">
+            <Label htmlFor="justificativa">Justificativa</Label>
+            <Textarea id="justificativa" {...register('justificativa')} placeholder="Justificativa (opcional)" rows={3} />
+            {errors.justificativa && <p className="text-sm text-destructive">{errors.justificativa.message}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="observacoes">Observações</Label>
+            <Textarea id="observacoes" {...register('observacoes')} placeholder="Observações (opcional)" rows={3} />
+            {errors.observacoes && <p className="text-sm text-destructive">{errors.observacoes.message}</p>}
+          </div>
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/rh/ausencias/nova/page.tsx
+++ b/apps/erp/src/app/(dashboard)/rh/ausencias/nova/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * Nova Ausência — Server Component shell.
+ */
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { PageHeader } from '@/components/patterns';
+import { NovaAusenciaForm } from './_components/nova-ausencia-form';
+
+export default async function NovaAusenciaPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+
+  return (
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Nova Ausência"
+        description="Registe uma ausência de um colaborador"
+        breadcrumbs={[
+          { label: 'RH', href: '/rh' },
+          { label: 'Ausências', href: '/rh/ausencias' },
+          { label: 'Nova' },
+        ]}
+      />
+      <NovaAusenciaForm />
+    </div>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/servicos/categorias/novo/_components/nova-categoria-servico-form.tsx
+++ b/apps/erp/src/app/(dashboard)/servicos/categorias/novo/_components/nova-categoria-servico-form.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Save, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { criarCategoriaServicoAction } from '@/server/actions/servicos.actions';
+
+const FormSchema = z.object({
+  nome: z.string().min(1, 'Nome obrigatório').max(100),
+  descricao: z.string().max(500).optional(),
+  icone: z.string().max(50).optional(),
+  ativo: z.boolean().default(true),
+  ordem: z.coerce.number().int().optional(),
+});
+type FormValues = z.infer<typeof FormSchema>;
+
+export function NovaCategoriaServicoForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: { nome: '', descricao: '', icone: '', ativo: true },
+  });
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const result = await criarCategoriaServicoAction({
+        nome: values.nome,
+        descricao: values.descricao || undefined,
+        icone: values.icone || undefined,
+        ativo: values.ativo,
+        ordem: values.ordem,
+      } as any);
+      if (result?.ok) {
+        toast.success('Categoria criada com sucesso.');
+        router.push('/servicos/categorias');
+      } else {
+        toast.error((result as any)?.error?.message ?? 'Erro ao criar categoria.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/servicos/categorias')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A criar…' : 'Criar Categoria'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Categoria" description="Identificação da categoria de serviço">
+          <div className="space-y-2">
+            <Label htmlFor="nome">Nome *</Label>
+            <Input id="nome" {...register('nome')} placeholder="Ex.: Manutenção" />
+            {errors.nome && <p className="text-sm text-destructive">{errors.nome.message}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="descricao">Descrição</Label>
+            <Textarea id="descricao" {...register('descricao')} placeholder="Descrição (opcional)" rows={3} />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="ordem">Ordem</Label>
+              <Input id="ordem" type="number" {...register('ordem')} placeholder="Ordem de apresentação" />
+            </div>
+            <div className="flex items-center gap-2 pt-6">
+              <Switch id="ativo" checked={watch('ativo')} onCheckedChange={(v) => setValue('ativo', v)} />
+              <Label htmlFor="ativo">Ativa</Label>
+            </div>
+          </div>
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/servicos/categorias/novo/page.tsx
+++ b/apps/erp/src/app/(dashboard)/servicos/categorias/novo/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * Nova Categoria de Serviço — Server Component shell.
+ */
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { PageHeader } from '@/components/patterns';
+import { NovaCategoriaServicoForm } from './_components/nova-categoria-servico-form';
+
+export default async function NovaCategoriaServicoPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+
+  return (
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Nova Categoria de Serviço"
+        description="Organize os serviços por categoria"
+        breadcrumbs={[
+          { label: 'Serviços', href: '/servicos' },
+          { label: 'Categorias', href: '/servicos/categorias' },
+          { label: 'Nova' },
+        ]}
+      />
+      <NovaCategoriaServicoForm />
+    </div>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/tickets/base-conhecimento/novo/_components/novo-artigo-base-conhecimento-form.tsx
+++ b/apps/erp/src/app/(dashboard)/tickets/base-conhecimento/novo/_components/novo-artigo-base-conhecimento-form.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Save, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { criarArtigoBaseConhecimentoAction } from '@/server/actions/tickets.actions';
+
+const FormSchema = z.object({
+  titulo: z.string().min(3, 'Título deve ter pelo menos 3 caracteres').max(300),
+  conteudo: z.string().min(10, 'Conteúdo obrigatório (mínimo 10 caracteres)'),
+  resumo: z.string().max(500).optional(),
+  categoria: z.string().min(1, 'Categoria obrigatória').max(100),
+  tags: z.string().optional(),
+});
+type FormValues = z.infer<typeof FormSchema>;
+
+export function NovoArtigoBaseConhecimentoForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: { titulo: '', conteudo: '', resumo: '', categoria: '', tags: '' },
+  });
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const tags = (values.tags ?? '')
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean);
+      const result = await criarArtigoBaseConhecimentoAction({
+        titulo: values.titulo,
+        conteudo: values.conteudo,
+        resumo: values.resumo || undefined,
+        categoria: values.categoria,
+        tags,
+      } as never);
+      if (result?.ok) {
+        toast.success('Artigo criado com sucesso.');
+        router.push('/tickets/base-conhecimento');
+      } else {
+        toast.error(result?.error?.message ?? 'Erro ao criar artigo.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/tickets/base-conhecimento')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A criar…' : 'Criar Artigo'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Artigo" description="Conteúdo do artigo da base de conhecimento">
+          <div className="space-y-2">
+            <Label htmlFor="titulo">Título *</Label>
+            <Input id="titulo" {...register('titulo')} placeholder="Ex.: Como redefinir a palavra-passe" />
+            {errors.titulo && <p className="text-sm text-destructive">{errors.titulo.message}</p>}
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="categoria">Categoria *</Label>
+              <Input id="categoria" {...register('categoria')} placeholder="Ex.: Conta e Acesso" />
+              {errors.categoria && <p className="text-sm text-destructive">{errors.categoria.message}</p>}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="tags">Tags</Label>
+              <Input id="tags" {...register('tags')} placeholder="Separadas por vírgula (opcional)" />
+              <p className="text-xs text-muted-foreground">Ex.: palavra-passe, login, segurança</p>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="resumo">Resumo</Label>
+            <Textarea id="resumo" {...register('resumo')} placeholder="Resumo breve (opcional)" rows={2} />
+            {errors.resumo && <p className="text-sm text-destructive">{errors.resumo.message}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="conteudo">Conteúdo *</Label>
+            <Textarea
+              id="conteudo"
+              {...register('conteudo')}
+              placeholder="Escreva o conteúdo do artigo…"
+              rows={12}
+            />
+            {errors.conteudo && <p className="text-sm text-destructive">{errors.conteudo.message}</p>}
+          </div>
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/tickets/base-conhecimento/novo/page.tsx
+++ b/apps/erp/src/app/(dashboard)/tickets/base-conhecimento/novo/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * Novo Artigo da Base de Conhecimento — Server Component shell.
+ */
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { PageHeader } from '@/components/patterns';
+import { NovoArtigoBaseConhecimentoForm } from './_components/novo-artigo-base-conhecimento-form';
+
+export default async function NovoArtigoBaseConhecimentoPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+
+  return (
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Novo Artigo"
+        description="Adicione um artigo à base de conhecimento"
+        breadcrumbs={[
+          { label: 'Tickets', href: '/tickets' },
+          { label: 'Base de Conhecimento', href: '/tickets/base-conhecimento' },
+          { label: 'Novo' },
+        ]}
+      />
+      <NovoArtigoBaseConhecimentoForm />
+    </div>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/tickets/categorias/nova/_components/nova-categoria-ticket-form.tsx
+++ b/apps/erp/src/app/(dashboard)/tickets/categorias/nova/_components/nova-categoria-ticket-form.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Save, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { criarCategoriaTicketAction } from '@/server/actions/tickets.actions';
+
+const FormSchema = z.object({
+  nome: z.string().min(1, 'Nome obrigatório').max(100),
+  descricao: z.string().max(500).optional(),
+  icone: z.string().max(50).optional(),
+  cor: z
+    .string()
+    .regex(/^#[0-9A-Fa-f]{6}$/, 'Cor deve ser hex válido (ex: #3b82f6)')
+    .optional()
+    .or(z.literal('')),
+  subcategorias: z.string().optional(),
+  slaTempoResposta: z.coerce.number().int().positive('Tempo de resposta deve ser positivo'),
+  slaTempoResolucao: z.coerce.number().int().positive('Tempo de resolução deve ser positivo'),
+});
+type FormValues = z.infer<typeof FormSchema>;
+
+export function NovaCategoriaTicketForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: { nome: '', descricao: '', icone: '', cor: '', subcategorias: '' },
+  });
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const subcategorias = (values.subcategorias ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const result = await criarCategoriaTicketAction({
+        nome: values.nome,
+        descricao: values.descricao || undefined,
+        icone: values.icone || undefined,
+        cor: values.cor || undefined,
+        subcategorias,
+        slaTempoResposta: Number(values.slaTempoResposta),
+        slaTempoResolucao: Number(values.slaTempoResolucao),
+      } as never);
+      if (result?.ok) {
+        toast.success('Categoria criada com sucesso.');
+        router.push('/tickets/categorias');
+      } else {
+        toast.error(result?.error?.message ?? 'Erro ao criar categoria.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/tickets/categorias')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A criar…' : 'Criar Categoria'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Categoria" description="Identificação da categoria de suporte">
+          <div className="space-y-2">
+            <Label htmlFor="nome">Nome *</Label>
+            <Input id="nome" {...register('nome')} placeholder="Ex.: Suporte Técnico" />
+            {errors.nome && <p className="text-sm text-destructive">{errors.nome.message}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="descricao">Descrição</Label>
+            <Textarea id="descricao" {...register('descricao')} placeholder="Descrição (opcional)" rows={3} />
+            {errors.descricao && <p className="text-sm text-destructive">{errors.descricao.message}</p>}
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="icone">Ícone</Label>
+              <Input id="icone" {...register('icone')} placeholder="Nome do ícone (opcional)" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cor">Cor</Label>
+              <Input id="cor" {...register('cor')} placeholder="#3b82f6" />
+              {errors.cor && <p className="text-sm text-destructive">{errors.cor.message}</p>}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="subcategorias">Subcategorias</Label>
+            <Input
+              id="subcategorias"
+              {...register('subcategorias')}
+              placeholder="Separadas por vírgula (opcional)"
+            />
+            <p className="text-xs text-muted-foreground">Ex.: Hardware, Software, Rede</p>
+          </div>
+        </FormSection>
+
+        <FormSection title="SLA" description="Tempos de resposta e resolução (em minutos)">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="slaTempoResposta">Tempo de Resposta *</Label>
+              <Input
+                id="slaTempoResposta"
+                type="number"
+                min="1"
+                {...register('slaTempoResposta')}
+                placeholder="Ex.: 60"
+              />
+              {errors.slaTempoResposta && (
+                <p className="text-sm text-destructive">{errors.slaTempoResposta.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="slaTempoResolucao">Tempo de Resolução *</Label>
+              <Input
+                id="slaTempoResolucao"
+                type="number"
+                min="1"
+                {...register('slaTempoResolucao')}
+                placeholder="Ex.: 480"
+              />
+              {errors.slaTempoResolucao && (
+                <p className="text-sm text-destructive">{errors.slaTempoResolucao.message}</p>
+              )}
+            </div>
+          </div>
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/tickets/categorias/nova/page.tsx
+++ b/apps/erp/src/app/(dashboard)/tickets/categorias/nova/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * Nova Categoria de Ticket — Server Component shell.
+ */
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { PageHeader } from '@/components/patterns';
+import { NovaCategoriaTicketForm } from './_components/nova-categoria-ticket-form';
+
+export default async function NovaCategoriaTicketPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+
+  return (
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Nova Categoria de Ticket"
+        description="Defina categorias de suporte e os respetivos SLA"
+        breadcrumbs={[
+          { label: 'Tickets', href: '/tickets' },
+          { label: 'Categorias', href: '/tickets/categorias' },
+          { label: 'Nova' },
+        ]}
+      />
+      <NovaCategoriaTicketForm />
+    </div>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/vendas/comissoes/regras/nova/_components/nova-regra-comissao-form.tsx
+++ b/apps/erp/src/app/(dashboard)/vendas/comissoes/regras/nova/_components/nova-regra-comissao-form.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Save, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { FormPage, FormSection, UnsavedChangesGuard } from '@/components/patterns';
+import { criarRegraComissao } from '@/server/actions/comissoes.actions';
+
+const TIPOS = [
+  { value: 'FIXA', label: 'Fixa' },
+  { value: 'ESCALONADA', label: 'Escalonada' },
+  { value: 'POR_CATEGORIA', label: 'Por Categoria' },
+  { value: 'POR_META', label: 'Por Meta' },
+  { value: 'POR_PERIODO', label: 'Por Período' },
+] as const;
+
+const FormSchema = z
+  .object({
+    nome: z.string().min(2, 'Nome obrigatório').max(100),
+    tipo: z.enum(['FIXA', 'ESCALONADA', 'POR_CATEGORIA', 'POR_META', 'POR_PERIODO']),
+    percentualBase: z.coerce.number().min(0, 'Percentual não pode ser negativo').max(100, 'Percentual não pode exceder 100'),
+    descricao: z.string().min(1, 'Descrição obrigatória').max(500),
+    prioridade: z.coerce.number().int().min(1).max(99).default(1),
+    ativa: z.boolean().default(true),
+    vendedorId: z.string().optional(),
+    percentualBonus: z.union([z.coerce.number().min(0).max(100), z.literal('')]).optional(),
+    dataInicio: z.string().optional(),
+    dataFim: z.string().optional(),
+  })
+  .refine(
+    (d) => {
+      if (d.dataInicio && d.dataFim) return d.dataInicio <= d.dataFim;
+      return true;
+    },
+    { message: 'Data de início deve ser anterior à data de fim', path: ['dataFim'] },
+  );
+type FormValues = z.infer<typeof FormSchema>;
+
+export function NovaRegraComissaoForm() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      nome: '',
+      tipo: 'FIXA',
+      percentualBase: 0,
+      descricao: '',
+      prioridade: 1,
+      ativa: true,
+      vendedorId: '',
+      percentualBonus: '',
+      dataInicio: '',
+      dataFim: '',
+    },
+  });
+
+  const onSubmit = handleSubmit((values) => {
+    startTransition(async () => {
+      const result = await criarRegraComissao({
+        nome: values.nome,
+        tipo: values.tipo,
+        percentualBase: Number(values.percentualBase),
+        descricao: values.descricao,
+        prioridade: Number(values.prioridade),
+        ativa: values.ativa,
+        vendedorId: values.vendedorId || undefined,
+        percentualBonus:
+          values.percentualBonus === '' || values.percentualBonus === undefined
+            ? undefined
+            : Number(values.percentualBonus),
+        dataInicio: values.dataInicio || undefined,
+        dataFim: values.dataFim || undefined,
+      } as never);
+      if (result?.ok) {
+        toast.success('Regra de comissão criada com sucesso.');
+        router.push('/vendas/comissoes');
+      } else {
+        toast.error(result?.error?.message ?? 'Erro ao criar regra de comissão.');
+      }
+    });
+  });
+
+  return (
+    <>
+      <UnsavedChangesGuard isDirty={isDirty} />
+      <FormPage
+        actions={
+          <>
+            <Button type="button" variant="ghost" onClick={() => router.push('/vendas/comissoes')}>
+              <X className="h-4 w-4 mr-2" />
+              Cancelar
+            </Button>
+            <Button type="button" disabled={isPending} onClick={onSubmit}>
+              <Save className="h-4 w-4 mr-2" />
+              {isPending ? 'A criar…' : 'Criar Regra'}
+            </Button>
+          </>
+        }
+      >
+        <FormSection title="Regra" description="Identificação e tipo da regra de comissão">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="nome">Nome *</Label>
+              <Input id="nome" {...register('nome')} placeholder="Ex.: Comissão padrão" />
+              {errors.nome && <p className="text-sm text-destructive">{errors.nome.message}</p>}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="tipo">Tipo *</Label>
+              <Select value={watch('tipo')} onValueChange={(v) => setValue('tipo', v as FormValues['tipo'])}>
+                <SelectTrigger id="tipo" aria-label="Tipo de regra">
+                  <SelectValue placeholder="Seleccione o tipo" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TIPOS.map((t) => (
+                    <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {errors.tipo && <p className="text-sm text-destructive">{errors.tipo.message}</p>}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="descricao">Descrição *</Label>
+            <Textarea id="descricao" {...register('descricao')} placeholder="Descrição da regra" rows={3} />
+            {errors.descricao && <p className="text-sm text-destructive">{errors.descricao.message}</p>}
+          </div>
+        </FormSection>
+
+        <FormSection title="Cálculo" description="Percentuais, prioridade e aplicação">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="percentualBase">Percentual Base (%) *</Label>
+              <Input
+                id="percentualBase"
+                type="number"
+                min="0"
+                max="100"
+                step="0.01"
+                {...register('percentualBase')}
+                placeholder="Ex.: 5"
+              />
+              {errors.percentualBase && (
+                <p className="text-sm text-destructive">{errors.percentualBase.message}</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="percentualBonus">Percentual Bónus (%)</Label>
+              <Input
+                id="percentualBonus"
+                type="number"
+                min="0"
+                max="100"
+                step="0.01"
+                {...register('percentualBonus')}
+                placeholder="Opcional"
+              />
+              {errors.percentualBonus && (
+                <p className="text-sm text-destructive">{errors.percentualBonus.message as string}</p>
+              )}
+            </div>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="prioridade">Prioridade</Label>
+              <Input id="prioridade" type="number" min="1" max="99" {...register('prioridade')} placeholder="1" />
+              {errors.prioridade && <p className="text-sm text-destructive">{errors.prioridade.message}</p>}
+            </div>
+            <div className="flex items-center gap-2 pt-6">
+              <Switch id="ativa" checked={watch('ativa')} onCheckedChange={(v) => setValue('ativa', v)} />
+              <Label htmlFor="ativa">Ativa</Label>
+            </div>
+          </div>
+        </FormSection>
+
+        <FormSection title="Aplicação (opcional)" description="Restringir a um vendedor ou período">
+          <div className="space-y-2">
+            <Label htmlFor="vendedorId">ID do Vendedor</Label>
+            <Input id="vendedorId" {...register('vendedorId')} placeholder="ID do vendedor (CUID) — opcional" />
+            {errors.vendedorId && <p className="text-sm text-destructive">{errors.vendedorId.message}</p>}
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="dataInicio">Data de Início</Label>
+              <Input id="dataInicio" type="date" {...register('dataInicio')} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="dataFim">Data de Fim</Label>
+              <Input id="dataFim" type="date" {...register('dataFim')} />
+              {errors.dataFim && <p className="text-sm text-destructive">{errors.dataFim.message}</p>}
+            </div>
+          </div>
+        </FormSection>
+      </FormPage>
+    </>
+  );
+}

--- a/apps/erp/src/app/(dashboard)/vendas/comissoes/regras/nova/page.tsx
+++ b/apps/erp/src/app/(dashboard)/vendas/comissoes/regras/nova/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * Nova Regra de Comissão — Server Component shell.
+ */
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { PageHeader } from '@/components/patterns';
+import { NovaRegraComissaoForm } from './_components/nova-regra-comissao-form';
+
+export default async function NovaRegraComissaoPage() {
+  const session = await auth();
+  if (!session?.user) redirect('/auth/login');
+
+  return (
+    <div className="p-6 space-y-6">
+      <PageHeader
+        title="Nova Regra de Comissão"
+        description="Defina as condições de cálculo de comissões"
+        breadcrumbs={[
+          { label: 'Vendas', href: '/vendas' },
+          { label: 'Comissões', href: '/vendas/comissoes' },
+          { label: 'Nova Regra' },
+        ]}
+      />
+      <NovaRegraComissaoForm />
+    </div>
+  );
+}


### PR DESCRIPTION
## Correção consolidada de rotas 404 (formulários de criação + link de suporte)

Junta os PRs #27, #28 e #29 num só (ficheiros disjuntos, todos independentes), sobre a `main` já com a Wave 7 (#26). Origem: varredura sistemática de links internos vs `page.tsx` existentes.

### 1. Formulários de criação em falta (backend já existia — ADR-0003, só faltava a UI)
Cada rota: `page.tsx` Server Component + `_components/*-form.tsx` folha `'use client'` (RHF + `zodResolver` com o schema real, submit via action existente, sem modais, tokens `@theme`, PT-PT; IDs relacionados como inputs CUID).

| Rota (404 → OK) | Action |
|---|---|
| `faturacao/cotacoes/nova` (cotação comercial) | `criarCotacaoComercial` |
| `servicos/categorias/novo` | `criarCategoriaServicoAction` |
| `tickets/categorias/nova` | `criarCategoriaTicketAction` |
| `tickets/base-conhecimento/novo` | `criarArtigoBaseConhecimentoAction` |
| `rh/ausencias/nova` | `registarAusenciaAction` |
| `vendas/comissoes/regras/nova` | `criarRegraComissao` |
| `projetos/orcamento/novo` | `criarOrcamentoProjetoAction` |
| `compras/cotacoes/novo` | `criarCotacaoAction` |
| `compras/pedidos/novo` | `criarPedidoCompraAction` |
| `faturacao/nota-credito/nova` | `emitirNotaCredito` |

### 2. `faturacao/proforma/nova` — mock → real
Era um mock (`'use client'` page com clientes hardcoded, submit falso via `setTimeout`, sem chamar a action). Substituído pelo padrão real ligado a `criarProforma`.

### 3. `/contactos` — link morto do login
"Contacto suporte 24/7" ligava a `/contactos` inexistente. Nova página pública (`(auth)/contactos`) + `/contactos` nos `PUBLIC_PATHS`. Conteúdo honesto (sem contactos fabricados): orienta para o administrador da organização; canal técnico "a definir pela organização".

### Verificação (branch consolidada, sobre a main com Wave 7)
- `tsc --noEmit` → EXIT 0 · `pnpm gates` → verde · `pnpm build` → compila, as 12 rotas emitem
- Smoke: `/contactos` → 200 sem sessão; rota protegida → 307 (middleware intacto)
- Re-varredura de rotas anunciadas-mas-inexistentes: **0**

Substitui #27, #28, #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
